### PR TITLE
use compnerd/cmake's build of wasi-libc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,9 @@ build/wasi-libc.BUILT: build/llvm.BUILT
 		-DCMAKE_C_COMPILER=$(PREFIX)/bin/clang \
 		-DCMAKE_C_COMPILER_WORKS=YES \
 		$(ROOT_DIR)/src/wasi-libc
-	ninja $(NINJA_FLAGS) -v -C build/wasi-libc \
-		install
+	ninja $(NINJA_FLAGS) -v -C build/wasi-libc
+	mkdir -p $(PREFIX)/share
+	cp -R build/wasi-libc/sysroot $(PREFIX)/share/wasi-sysroot
 	touch build/wasi-libc.BUILT
 
 build/compiler-rt.BUILT: build/wasi-libc.BUILT build/llvm.BUILT

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ build/llvm.BUILT:
 
 build/wasi-libc.BUILT: build/llvm.BUILT
 	cmake -G Ninja \
-		--install \
 		-DCMAKE_SYSTEM_NAME=Generic \
 		-DCMAKE_AR=$(PREFIX)/bin/ar \
 		-DCMAKE_NM=$(PREFIX)/bin/nm \
@@ -61,6 +60,8 @@ build/wasi-libc.BUILT: build/llvm.BUILT
 		-DCMAKE_C_COMPILER_WORKS=YES \
 		-B build/wasi-libc \
 		-S $(ROOT_DIR)/src/wasi-libc
+	ninja $(NINJA_FLAGS) -v -C build/wasi-libc \
+		install
 	touch build/wasi-libc.BUILT
 
 build/compiler-rt.BUILT: build/wasi-libc.BUILT build/llvm.BUILT

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build/llvm.BUILT:
 
 build/wasi-libc.BUILT: build/llvm.BUILT
 	cmake -G Ninja \
-		--build \
+		--install \
 		-DCMAKE_SYSTEM_NAME=Generic \
 		-DCMAKE_AR=$(ROOT_DIR)/bin/llvm-ar \
 		-DCMAKE_NM=$(ROOT_DIR)/bin/llvm-nm \

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,14 @@ build/llvm.BUILT:
 	touch build/llvm.BUILT
 
 build/wasi-libc.BUILT: build/llvm.BUILT
-	cmake -G Ninja \
+	mkdir -p build/wasi-libc
+	cd build/wasi-libc; cmake -G Ninja \
 		-DCMAKE_SYSTEM_NAME=Generic \
 		-DCMAKE_AR=$(PREFIX)/bin/ar \
 		-DCMAKE_NM=$(PREFIX)/bin/nm \
 		-DCMAKE_C_COMPILER=$(PREFIX)/bin/clang \
 		-DCMAKE_C_COMPILER_WORKS=YES \
-		-B build/wasi-libc \
-		-S $(ROOT_DIR)/src/wasi-libc
+		$(ROOT_DIR)/src/wasi-libc
 	ninja $(NINJA_FLAGS) -v -C build/wasi-libc \
 		install
 	touch build/wasi-libc.BUILT

--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,14 @@ build/llvm.BUILT:
 	touch build/llvm.BUILT
 
 build/wasi-libc.BUILT: build/llvm.BUILT
-	cmake -G Ninja -B build/wasi-libc \
+	cmake -G Ninja \
+		--build \
 		-DCMAKE_SYSTEM_NAME=Generic \
 		-DCMAKE_AR=$(ROOT_DIR)/bin/llvm-ar \
 		-DCMAKE_NM=$(ROOT_DIR)/bin/llvm-nm \
 		-DCMAKE_C_COMPILER=$(ROOT_DIR)/bin/clang \
-		-S $(ROOT_DIR)/src/wasi-libc \
-		--build
+		-B build/wasi-libc \
+		-S $(ROOT_DIR)/src/wasi-libc
 	touch build/wasi-libc.BUILT
 
 build/compiler-rt.BUILT: build/llvm.BUILT

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,13 @@ build/llvm.BUILT:
 	touch build/llvm.BUILT
 
 build/wasi-libc.BUILT: build/llvm.BUILT
-	$(MAKE) -C $(ROOT_DIR)/src/wasi-libc \
-		WASM_CC=$(PREFIX)/bin/clang \
-		SYSROOT=$(PREFIX)/share/wasi-sysroot
+	cmake -G Ninja -B build/wasi-libc \
+		-DCMAKE_SYSTEM_NAME=Generic \
+		-DCMAKE_AR=$(ROOT_DIR)/bin/llvm-ar \
+		-DCMAKE_NM=$(ROOT_DIR)/bin/llvm-nm \
+		-DCMAKE_C_COMPILER=$(ROOT_DIR)/bin/clang \
+		-S $(ROOT_DIR)/src/wasi-libc \
+		--build
 	touch build/wasi-libc.BUILT
 
 build/compiler-rt.BUILT: build/llvm.BUILT

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ build/wasi-libc.BUILT: build/llvm.BUILT
 	cmake -G Ninja \
 		--install \
 		-DCMAKE_SYSTEM_NAME=Generic \
-		-DCMAKE_AR=$(ROOT_DIR)/bin/llvm-ar \
-		-DCMAKE_NM=$(ROOT_DIR)/bin/llvm-nm \
-		-DCMAKE_C_COMPILER=$(ROOT_DIR)/bin/clang \
+		-DCMAKE_AR=$(PREFIX)/bin/ar \
+		-DCMAKE_NM=$(PREFIX)/bin/nm \
+		-DCMAKE_C_COMPILER=$(PREFIX)/bin/clang \
 		-B build/wasi-libc \
 		-S $(ROOT_DIR)/src/wasi-libc
 	touch build/wasi-libc.BUILT

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ build/wasi-libc.BUILT: build/llvm.BUILT
 		-DCMAKE_AR=$(PREFIX)/bin/ar \
 		-DCMAKE_NM=$(PREFIX)/bin/nm \
 		-DCMAKE_C_COMPILER=$(PREFIX)/bin/clang \
+		-DCMAKE_C_COMPILER_WORKS=YES \
 		-B build/wasi-libc \
 		-S $(ROOT_DIR)/src/wasi-libc
 	touch build/wasi-libc.BUILT

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ build/wasi-libc.BUILT: build/llvm.BUILT
 		-S $(ROOT_DIR)/src/wasi-libc
 	touch build/wasi-libc.BUILT
 
-build/compiler-rt.BUILT: build/llvm.BUILT
+build/compiler-rt.BUILT: build/wasi-libc.BUILT build/llvm.BUILT
 	mkdir -p build/compiler-rt
 	cd build/compiler-rt; cmake -G Ninja \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
Using this PR to get the CI system to try building with wasi-libc's new CMamke based build system, by @compnerd

https://github.com/CraneStation/wasi-libc/pull/154#issuecomment-573383839