### PR TITLE
Fix `strip_symbols.sh` on mac; bump libc to include utime.h

### DIFF
--- a/strip_symbols.sh
+++ b/strip_symbols.sh
@@ -1,8 +1,14 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -e
 
 DIRECTORY=${1:-/opt/wasi-sdk/bin}
+if [[ "$OSTYPE" == "darwin"* ]]; then
+# macos find doesnt support -executable so we fall back on having a permission
+# bit to execute:
+EXECUTABLES=$(find ${DIRECTORY} -type f -perm +111)
+else
 EXECUTABLES=$(find ${DIRECTORY} -type f -executable)
+fi
 for e in ${EXECUTABLES}; do
   echo "Stripping symbols: ${e}"
   strip ${e} || echo "Failed to strip symbols for ${e}; continuing on."


### PR DESCRIPTION
Fix for `strip_symbols.sh` should fix Mac OS CI.

Bump of libc submodule gets latest change to have utime.h included again.

These are the last blocking issues for the wasi-sdk-9 release, so once we merge this I'll tag it.