### PR TITLE
More CI Fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       - name: Build
         run: sudo make -j4 package
+        if: matrix.os != 'windows-latest'
+      - name: Build
+        run: make -j4 package
         shell: bash
+        if: matrix.os == 'windows-latest'
       - name: Run the testsuite
         run: make check
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Native Build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -43,4 +43,20 @@ jobs:
         with:
           # Upload the dist folder. Give it a name according to the OS it was built for.
           name: ${{ format( 'dist-{0}.tgz', matrix.os) }}
+          path: dist
+
+  dockerbuild:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: Run docker_build script
+        run: ./docker_build.sh
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          # Upload the dist folder. Give it a name according to the OS it was built for.
+          name: dist-docker.tgz
           path: dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          # llvm 9 build is broken on windows for now. Re-enable this when it is fixed:
-          # - windows-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           # Upload the dist folder. Give it a name according to the OS it was built for.
-          name: ${{ format( 'dist-{0}.tgz', matrix.os) }}
+          name: ${{ format( 'dist-{0}', matrix.os) }}
           path: dist
 
   dockerbuild:
@@ -64,5 +64,5 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           # Upload the dist folder. Give it a name according to the OS it was built for.
-          name: dist-docker.tgz
+          name: dist-debian-stretch
           path: dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       - name: Build
         run: sudo make -j4 package
+        shell: bash
       - name: Run the testsuite
         run: make check
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,9 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
+          # Build still fails on windows - sysroot path passed to compiler-rt
+          # is incorrect.
+          # - windows-latest
     steps:
       - uses: actions/checkout@v1
         with:

--- a/deb_from_installation.sh
+++ b/deb_from_installation.sh
@@ -18,4 +18,4 @@ mkdir -p build/pkg/DEBIAN
 sed -e s/VERSION/$VERSION/ wasi-sdk.control > build/pkg/DEBIAN/control
 cp -R /opt/wasi-sdk build/pkg/opt/
 cd build && dpkg-deb -b pkg wasi-sdk_$VERSION\_amd64.deb && cd ..
-mv build/wasi-sdk_$VERSION\amd64.deb $OUTDIR/
+mv build/wasi-sdk_$VERSION\_amd64.deb $OUTDIR/

--- a/deb_from_installation.sh
+++ b/deb_from_installation.sh
@@ -17,5 +17,5 @@ mkdir -p build/pkg/opt
 mkdir -p build/pkg/DEBIAN
 sed -e s/VERSION/$VERSION/ wasi-sdk.control > build/pkg/DEBIAN/control
 cp -R /opt/wasi-sdk build/pkg/opt/
-cd build && dpkg-deb -b pkg wasi-sdk_$VERSION\_amd64.deb
+cd build && dpkg-deb -b pkg wasi-sdk_$VERSION\_amd64.deb && cd ..
 mv build/wasi-sdk_$VERSION\amd64.deb $OUTDIR/


### PR DESCRIPTION
The Dockerfile bitrotted because it isn't checked in CI.

Sam fixed the cmake version issue in #120. This PR adds a job to run `docker_build.sh` (in addition to the regular native `ubuntu-latest` build) in CI.

It also re-enables Windows.

If successful, we'll merge this PR and tag the result as version `wasi-sdk-10`. We'll leave a note on `wasi-sdk-9` that it has been superseded by this new release.  And we'll use the artifacts from the CI for the `create: tag` trigger as the release binaries.
