### PR TITLE
Build and test SDK without requiring root (sudo) access

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,8 @@ jobs:
         run: sudo apt install ninja-build
         if: matrix.os == 'ubuntu-latest'
       - name: Build
-        run: sudo make package
-        if: matrix.os != 'windows-latest'
-      - name: Build
         run: make package
         shell: bash
-        if: matrix.os == 'windows-latest'
       - name: Run the testsuite
         run: make check
         if: matrix.os == 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ESCAPE_SLASH=/
 # assuming we're running under msys2 (git-bash), PATH needs /c/foo format directories (because
 # it itself is :-delimited)
 DESTDIR=$(abspath build/install)
-BUILD_PREFIX=$(DESTDIR)$(shell cygpath.exe -u $(PREFIX))
+BUILD_PREFIX=$(DESTDIR)/wasi-sdk
 
 else
 
@@ -111,7 +111,7 @@ build/compiler-rt.BUILT: build/llvm.BUILT
 		$(LLVM_PROJ_DIR)/compiler-rt/lib/builtins
 	DESTDIR=$(DESTDIR) ninja $(NINJA_FLAGS) -v -C build/compiler-rt install
 	# Install clang-provided headers.
-	cp -R $(ROOT_DIR)/build/llvm/lib/clang $(DESTDIR)$(PREFIX)/lib/
+	cp -R $(ROOT_DIR)/build/llvm/lib/clang $(BUILD_PREFIX)/lib/
 	touch build/compiler-rt.BUILT
 
 # Flags for libcxx.

--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,18 @@ endif
 # because it tries to path-expand the / into the msys root.  // escapes this.
 ESCAPE_SLASH=/
 
+BUILD_PREFIX=$(PREFIX)
+
 # assuming we're running under msys2 (git-bash), PATH needs /c/foo format directories (because
 # it itself is :-delimited)
-BUILD_PREFIX=$(shell cygpath.exe -u $(PREFIX))
+PATH_PREFIX=$(shell cygpath.exe -u $(BUILD_PREFIX))
 
 else
 
 PREFIX?=/opt/wasi-sdk
 DESTDIR=$(abspath build/install)
 BUILD_PREFIX=$(DESTDIR)$(PREFIX)
+PATH_PREFIX=$(BUILD_PREFIX)
 ESCAPE_SLASH?=
 BASH=
 
@@ -44,8 +47,7 @@ default: build
 check:
 	CC="clang --sysroot=$(BUILD_PREFIX)/share/wasi-sysroot" \
 	CXX="clang++ --sysroot=$(BUILD_PREFIX)/share/wasi-sysroot" \
-	PATH="$(BUILD_PREFIX)/bin:$$PATH" \
-	  tests/run.sh
+	PATH="$(PATH_PREFIX)/bin:$$PATH" tests/run.sh
 
 clean:
 	rm -rf build $(DESTDIR)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LLVM_PROJ_DIR?=$(ROOT_DIR)/src/llvm-project
 # Windows needs munging
 ifeq ($(OS),Windows_NT)
 
-PREFIX=c:/wasi-sdk
+PREFIX?=c:/wasi-sdk
 # we need to explicitly call bash -c for makefile $(shell ...), otherwise we'll try under
 # who knows what
 BASH=bash -c
@@ -26,7 +26,7 @@ BUILD_PREFIX=$(shell cygpath.exe -u $(PREFIX))
 
 else
 
-PREFIX=/opt/wasi-sdk
+PREFIX?=/opt/wasi-sdk
 DESTDIR=$(abspath build/install)
 BUILD_PREFIX=$(DESTDIR)$(PREFIX)
 ESCAPE_SLASH?=

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ ESCAPE_SLASH=/
 
 # assuming we're running under msys2 (git-bash), PATH needs /c/foo format directories (because
 # it itself is :-delimited)
-DESTDIR=$(abspath build/install)
-BUILD_PREFIX=$(DESTDIR)/wasi-sdk
+BUILD_PREFIX=$(shell cygpath.exe -u $(PREFIX))
 
 else
 

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,15 @@ ESCAPE_SLASH=/
 DESTDIR=$(abspath build/install)
 BUILD_PREFIX=$(DESTDIR)$(shell cygpath.exe -u $(PREFIX))
 
-endif
+else
 
 PREFIX=/opt/wasi-sdk
 DESTDIR=$(abspath build/install)
 BUILD_PREFIX=$(DESTDIR)$(PREFIX)
 ESCAPE_SLASH?=
 BASH=
+
+endif
 
 CLANG_VERSION=$(shell $(BASH) ./llvm_version.sh $(LLVM_PROJ_DIR))
 VERSION:=$(shell $(BASH) ./version.sh)


### PR DESCRIPTION
We still build with the `/opt/wasi-sdk` prefix but we don't actually
install into that directory.  Instead we install into `build/install`.

The main different is that this requires the `--sysroot` flag when
running clang to build the testsuite.