### PR TITLE
Remove `-Wl,--no-threads` from linker flags

### DIFF
--- a/wasi-sdk.cmake
+++ b/wasi-sdk.cmake
@@ -22,7 +22,6 @@ set(CMAKE_C_COMPILER_TARGET ${triple} CACHE STRING "wasi-sdk build")
 set(CMAKE_CXX_COMPILER_TARGET ${triple} CACHE STRING "wasi-sdk build")
 set(CMAKE_C_FLAGS "-v" CACHE STRING "wasi-sdk build")
 set(CMAKE_CXX_FLAGS "-v -std=c++11" CACHE STRING "wasi-sdk build")
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-threads" CACHE STRING "wasi-sdk build")
 
 set(CMAKE_SYSROOT ${WASI_SDK_PREFIX}/share/wasi-sysroot CACHE STRING "wasi-sdk build")
 set(CMAKE_STAGING_PREFIX ${WASI_SDK_PREFIX}/share/wasi-sysroot CACHE STRING "wasi-sdk build")


### PR DESCRIPTION
I'm not sure why this was in here as it pre-dates the initial
commit.  I imagine it could be that there were bugs in the early version
of wasm-ld related to threading.

In recent version of lld this flag has been renamed:
  https://reviews.llvm.org/D76885