### PR TITLE
Remove support for clang/llvm 8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ build/llvm.BUILT:
 		install-llvm-ranlib \
 		install-llvm-strip \
 		install-llvm-dwarfdump \
-		$(if $(patsubst 8.%,,$(CLANG_VERSION)),install-clang-resource-headers,install-clang-headers) \
+		install-clang-resource-headers \
 		install-ar \
 		install-ranlib \
 		install-strip \
@@ -166,7 +166,7 @@ LIBCXXABI_CMAKE_FLAGS = \
     -DLIBCXXABI_HAS_EXTERNAL_THREAD_API:BOOL=OFF \
     -DLIBCXXABI_BUILD_EXTERNAL_THREAD_LIBRARY:BOOL=OFF \
     -DLIBCXXABI_HAS_WIN32_THREAD_API:BOOL=OFF \
-    $(if $(patsubst 8.%,,$(CLANG_VERSION)),-DLIBCXXABI_ENABLE_PIC:BOOL=OFF,) \
+    -DLIBCXXABI_ENABLE_PIC:BOOL=OFF \
     -DCXX_SUPPORTS_CXX11=ON \
     -DLLVM_COMPILER_CHECKED=ON \
     -DCMAKE_BUILD_TYPE=RelWithDebugInfo \

--- a/wasi-sdk.cmake
+++ b/wasi-sdk.cmake
@@ -22,7 +22,6 @@ set(CMAKE_C_COMPILER_TARGET ${triple} CACHE STRING "wasi-sdk build")
 set(CMAKE_CXX_COMPILER_TARGET ${triple} CACHE STRING "wasi-sdk build")
 set(CMAKE_C_FLAGS "-v" CACHE STRING "wasi-sdk build")
 set(CMAKE_CXX_FLAGS "-v -std=c++11" CACHE STRING "wasi-sdk build")
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-threads" CACHE STRING "wasi-sdk build")
 
 set(CMAKE_SYSROOT ${WASI_SDK_PREFIX}/share/wasi-sysroot CACHE STRING "wasi-sdk build")
 set(CMAKE_STAGING_PREFIX ${WASI_SDK_PREFIX}/share/wasi-sysroot CACHE STRING "wasi-sdk build")


### PR DESCRIPTION
Remove old workarounds for clang/llvm 8.0, which we'll no longer support, for building WASI libc or WASI sdk releases.

Removing `--no-threads` was recently discussed in https://reviews.llvm.org/D76885 .

Also related is https://github.com/WebAssembly/wasi-libc/issues/212 in which we're planning to remove an LLVM 8.0 workaround from WASI libc.