### PR TITLE
Support for LLVM 8.0 was dropped; update README.md accordingly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ wasi-libc tree.
 The libc portion of this SDK is the
 [wasi-libc](https://github.com/WebAssembly/wasi-libc).
 
-Upstream Clang and LLVM (from 8.0 onwards) can compile for WASI out of the box,
+Upstream Clang and LLVM (from 9.0 onwards) can compile for WASI out of the box,
 and WebAssembly support is included in them by default. So, all that's done here
 is to provide builds configured to set the default target and sysroot for
 convenience.


### PR DESCRIPTION
Support for LLVM 8.0 was
[recently dropped](https://github.com/WebAssembly/wasi-sdk/pull/151).
Update the README.md accordingly.

Fixes #155.