### PR TITLE
Build windows SDK with MSVC instead of gcc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
+      - name: Set up Visual Studio shell
+        uses: egor-tensin/vs-shell@v1
+        if: matrix.os == 'windows-latest'
       - name: Install ninja (Windows)
         run: choco install ninja
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           submodules: true
       - name: Set up Visual Studio shell
-        uses: egor-tensin/vs-shell@v1
+        uses: egor-tensin/vs-shell@6d88c01ad4b6b33190d261b45e241e462545652b
         if: matrix.os == 'windows-latest'
       - name: Install ninja (Windows)
         run: choco install ninja


### PR DESCRIPTION
By default, cmake was finding MSYS (or mingw, whichever) gcc in the path and building with it.  The resulting binaries therefore required `libgcc_s_seh-1.dll` to be available.

This executes a VS environment setup before the build, causing cmake to pick up on VC++ and generates a clean no-dependencies LLVM build (other than the Windows CRT).

Fixes #148 