### PR TITLE
fix deb build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ package: build/package.BUILT
 
 build/package.BUILT: build strip
 	mkdir -p dist
-	command -v dpkg-deb >/dev/null && ./deb_from_installation.sh $(shell pwd)/dist || true
+	./deb_from_installation.sh $(shell pwd)/dist "$(VERSION)" "$(BUILD_PREFIX)"
 	./tar_from_installation.sh "$(shell pwd)/dist" "$(VERSION)" "$(BUILD_PREFIX)"
 	touch build/package.BUILT
 

--- a/deb_from_installation.sh
+++ b/deb_from_installation.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env sh
+set -x
+
+command -v dpkg-deb >/dev/null
+if [ $? -eq 0 ]
+then
+else
+    echo "required tool dpkg-deb missing. exiting"
+    exit 0
+fi
+
 set -ex
+
 if [ -n "$1" ]; then
     OUTDIR=$1
 else
@@ -12,10 +23,21 @@ else
     VERSION=`./version.sh`
 fi
 
+if [ -n "$3" ]; then
+    INSTALL_DIR="$3"
+else
+    INSTALL_DIR=/opt/wasi-sdk
+fi
+
+if [ ! -d $INSTALL_DIR ] ; then
+    echo "Directory $INSTALL_DIR doesn't exist. Nothing to copy from."
+    exit 1
+fi
+
 rm -rf build/pkg
 mkdir -p build/pkg/opt
 mkdir -p build/pkg/DEBIAN
 sed -e s/VERSION/$VERSION/ wasi-sdk.control > build/pkg/DEBIAN/control
-cp -R /opt/wasi-sdk build/pkg/opt/
+cp -R $INSTALL_DIR build/pkg/opt/
 cd build && dpkg-deb -b pkg wasi-sdk_$VERSION\_amd64.deb && cd ..
 mv build/wasi-sdk_$VERSION\_amd64.deb $OUTDIR/

--- a/deb_from_installation.sh
+++ b/deb_from_installation.sh
@@ -2,9 +2,7 @@
 set -x
 
 command -v dpkg-deb >/dev/null
-if [ $? -eq 0 ]
-then
-else
+if [ $? -ne 0 ]; then
     echo "required tool dpkg-deb missing. exiting"
     exit 0
 fi


### PR DESCRIPTION
change makefile and deb_from_installation to invoke it with the new
build directory (changed in #143).

deb_from_installation will exit 0 if dpkg-deb missing so we dont try
to run it as part of `make package` on non-deb systems, but other errors
should cause the makefile to fail, which should catch regressions like
this sooner in the future.