### PR TITLE
correct wasi-sdk branch name references from `master` to `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     tags:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # WASI SDK
 
-[![Build Status](https://dev.azure.com/CraneStation/wasi-sdk/_apis/build/status/CraneStation.wasi-sdk?branchName=master)](https://dev.azure.com/CraneStation/wasi-sdk/_build/latest?definitionId=2&branchName=master)
-
 ## Quick Start
 
 [Download SDK packages here.](https://github.com/WebAssembly/wasi-sdk/releases)


### PR DESCRIPTION
The build badge in README.md was way out of date - we no longer use azure
for CI and the urls were to the old cranestation location. So I deleted
it.

Closes https://github.com/WebAssembly/wasi-sdk/issues/147