### PR TITLE
In clang 11.0 and newer, use a relative sysroot path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,11 @@ build/llvm.BUILT:
 		-DLLVM_TARGETS_TO_BUILD=WebAssembly \
 		-DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-wasi \
 		-DLLVM_ENABLE_PROJECTS="lld;clang;clang-tools-extra" \
-		-DDEFAULT_SYSROOT=$(PREFIX)/share/wasi-sysroot \
+		$(if $(patsubst 9.%,,$(CLANG_VERSION)), \
+	             $(if $(patsubst 10.%,,$(CLANG_VERSION)), \
+		          -DDEFAULT_SYSROOT=../share/wasi-sysroot, \
+			  -DDEFAULT_SYSROOT=$(PREFIX)/share/wasi-sysroot), \
+		     -DDEFAULT_SYSROOT=$(PREFIX)/share/wasi-sysroot) \
 		-DLLVM_INSTALL_BINUTILS_SYMLINKS=TRUE \
 		$(LLVM_PROJ_DIR)/llvm
 	DESTDIR=$(DESTDIR) ninja $(NINJA_FLAGS) -v -C build/llvm \


### PR DESCRIPTION
This makes use of https://reviews.llvm.org/D76653, which is in clang 11
and newer, to fix #53. With this, clang can find the sysroot relative to
its own path.

Fixes #58.