### PR TITLE
Update to LLVM 13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # Use a relatively old/stable distro here to maximize the supported platforms
 # and avoid depending on more recent version of, say, libc.
-# Here we choose Xenial 16.04 which mean we also support Debian from stretch
-# (releases 2017) onwards.
-FROM ubuntu:xenial
+# Here we choose Bionic 18.04.
+FROM ubuntu:bionic
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sources mentioned above, and compile with
 
 A typical installation from the release binaries might look like the following:
 ```shell script
-export WASI_VERSION=13
+export WASI_VERSION=12
 export WASI_VERSION_FULL=${WASI_VERSION}.0
 wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
 tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sources mentioned above, and compile with
 
 A typical installation from the release binaries might look like the following:
 ```shell script
-export WASI_VERSION=12
+export WASI_VERSION=13
 export WASI_VERSION_FULL=${WASI_VERSION}.0
 wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
 tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz

--- a/tar_from_installation.sh
+++ b/tar_from_installation.sh
@@ -20,6 +20,7 @@ else
 fi
 
 PKGDIR=build/wasi-sdk-$VERSION
+mkdir -p build
 
 case "$(uname -s)" in
     Linux*)     MACHINE=linux;;

--- a/version.sh
+++ b/version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
-GIT_DESCR=$(git describe --long --candidates=999 --match='wasi-sdk-*' --dirty='+m' --abbrev=13)
-GIT_PACKAGE_VERSION=$(echo $GIT_DESCR | perl -ne 'if(/^wasi-sdk-(\d+)-(\d+)-g([0-9a-f]{7,13})([+]m)?$/) { if($2 == 0) { print "$1.$2$4" } else { print "$1.$2g$3$4" } exit } else { print "could not parse git description"; exit 1 }';)
+GIT_DESCR=$(git describe --long --candidates=999 --match='wasi-sdk-*' --dirty='+m' --abbrev=12)
+GIT_PACKAGE_VERSION=$(echo $GIT_DESCR | perl -ne 'if(/^wasi-sdk-(\d+)-(\d+)-g([0-9a-f]{7,12})([+]m)?$/) { if($2 == 0) { print "$1.$2$4" } else { print "$1.$2g$3$4" } exit } else { print "could not parse git description"; exit 1 }';)
 echo $GIT_PACKAGE_VERSION

--- a/version.sh
+++ b/version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
-GIT_DESCR=$(git describe --long --candidates=999 --match='wasi-sdk-*' --dirty='+m' --abbrev=12)
+GIT_DESCR=$(git describe --long --candidates=999 --match='wasi-sdk-*' --dirty='+m' --abbrev=13)
 GIT_PACKAGE_VERSION=$(echo $GIT_DESCR | perl -ne 'if(/^wasi-sdk-(\d+)-(\d+)-g([0-9a-f]{7,12})([+]m)?$/) { if($2 == 0) { print "$1.$2$4" } else { print "$1.$2g$3$4" } exit } else { print "could not parse git description"; exit 1 }';)
 echo $GIT_PACKAGE_VERSION

--- a/version.sh
+++ b/version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
 GIT_DESCR=$(git describe --long --candidates=999 --match='wasi-sdk-*' --dirty='+m' --abbrev=13)
-GIT_PACKAGE_VERSION=$(echo $GIT_DESCR | perl -ne 'if(/^wasi-sdk-(\d+)-(\d+)-g([0-9a-f]{7,12})([+]m)?$/) { if($2 == 0) { print "$1.$2$4" } else { print "$1.$2g$3$4" } exit } else { print "could not parse git description"; exit 1 }';)
+GIT_PACKAGE_VERSION=$(echo $GIT_DESCR | perl -ne 'if(/^wasi-sdk-(\d+)-(\d+)-g([0-9a-f]{7,13})([+]m)?$/) { if($2 == 0) { print "$1.$2$4" } else { print "$1.$2g$3$4" } exit } else { print "could not parse git description"; exit 1 }';)
 echo $GIT_PACKAGE_VERSION


### PR DESCRIPTION
This also changes the CI to build on bionic instead of xenial, which has a newer version of Python.

This pullls in llvm/llvm-project@1d445a6, which is needed by bytecodealliance/wizer#8 .

This supercedes #188, and updates to a released version.