### PR TITLE
Use standardized `CC`, `AR`, `NM` env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,9 @@ build/llvm.BUILT:
 
 build/wasi-libc.BUILT: build/llvm.BUILT
 	$(MAKE) -C $(ROOT_DIR)/src/wasi-libc \
-		WASM_CC=$(BUILD_PREFIX)/bin/clang \
+		CC=$(BUILD_PREFIX)/bin/clang \
+		AR=$(BUILD_PREFIX)/bin/llvm-ar \
+		NM=$(BUILD_PREFIX)/bin/llvm-nm \
 		SYSROOT=$(BUILD_PREFIX)/share/wasi-sysroot
 	touch build/wasi-libc.BUILT
 


### PR DESCRIPTION
Companion to https://github.com/WebAssembly/wasi-libc/pull/275