### PR TITLE
Add -fno-exceptions when testing C++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ default: build
 
 check:
 	CC="clang --sysroot=$(BUILD_PREFIX)/share/wasi-sysroot" \
-	CXX="clang++ --sysroot=$(BUILD_PREFIX)/share/wasi-sysroot" \
+	CXX="clang++ --sysroot=$(BUILD_PREFIX)/share/wasi-sysroot -fno-exceptions" \
 	PATH="$(PATH_PREFIX)/bin:$$PATH" tests/run.sh
 
 clean:


### PR DESCRIPTION
The build would fail with the following error message when testing with llvm trunk without `-fno-exceptions`. Of course it's not time to bump llvm in upstream wasi-sdk yet, but I believe `-fno-exceptions` is still a reasonable default C++ flag to add for now, before wasm exception handling is widely supported.

```
Testing iostream_main.cc...
Testing iostream_main.cc...
wasm-ld: error: /tmp/iostream_main-4595e6.o: undefined symbol: __cxa_allocate_exception
wasm-ld: error: /tmp/iostream_main-4595e6.o: undefined symbol: __cxa_throw
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:48: check] Error 1
```