### PR TITLE
Set `LLVM_ENABLE_LIBXML2` to `OFF`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ build/llvm.BUILT:
 			  -DDEFAULT_SYSROOT=$(PREFIX)/share/wasi-sysroot), \
 		     -DDEFAULT_SYSROOT=$(PREFIX)/share/wasi-sysroot) \
 		-DLLVM_INSTALL_BINUTILS_SYMLINKS=TRUE \
+		-DLLVM_ENABLE_LIBXML2=OFF \
 		$(LLVM_PROJ_DIR)/llvm
 	DESTDIR=$(DESTDIR) ninja $(NINJA_FLAGS) -C build/llvm \
 		install-clang \


### PR DESCRIPTION
This attempts to disable the use of libxml2. I am currently unaware of
any functionality needed by wasi-sdk users that involves reading XML
files.

Fixes #243.