### PR TITLE
Use an https URL instead of a git URL in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sources mentioned above, and compile with
 This repository uses git submodule, to clone it you need use the command below :
 
 ```shell script
-git clone --recursive  git@github.com:WebAssembly/wasi-sdk.git 
+git clone --recursive https://github.com/WebAssembly/wasi-sdk.git
 ```
 
 ## Requirements


### PR DESCRIPTION
Tre git URL requires a user to have configured git with github
credentials, so use an https URL instead.

Fixes #242.