### PR TITLE
Add llvm-mc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ build/llvm.BUILT:
 		install-clang-tidy \
 		install-clang-apply-replacements \
 		install-lld \
+		install-llvm-mc \
 		install-llvm-ranlib \
 		install-llvm-strip \
 		install-llvm-dwarfdump \


### PR DESCRIPTION
This PR adds `llvm-mc` to `wasi-sdk`. We intend to use `llvm-mc` instead of `clang` as a `wasm32` assembler, and this would allow us to pass `-no-type-check` to bypass the rather error-prone `wasm32` assembly type checker.