### PR TITLE
Use msys2 clang toolchain to build windows distribution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,42 +42,45 @@ jobs:
 
   winbuild:
     name: Windows Build
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - x64
-          - x86
-    env:
-      MSYS2_PATH_TYPE: inherit
-      MSYSTEM: MINGW64
-      CC: cl
-      CXX: cl
-      NINJA_FLAGS: -v
+        include:
+          - arch: x64
+            sys: clang64
+            env: clang-x86_64
+          - arch: x86
+            sys: clang32
+            env: clang-i686
     steps:
-      - uses: actions/checkout@v1
+      - uses: msys2/setup-msys2@v2
         with:
+          install: >-
+            base-devel
+            git
+            mingw-w64-${{ matrix.env }}-cmake
+            mingw-w64-${{ matrix.env }}-ninja
+            mingw-w64-${{ matrix.env }}-toolchain
+          msystem: ${{ matrix.sys }}
+          update: true
+          release: false
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
           submodules: true
-      - name: Install ninja (Windows)
-        run: choco install ninja
       - name: Build
-        shell: cmd
-        # vcvarsall.bat need explicit Visual Studio 2019 to be installed
+        shell: msys2 {0}
         run: |
-          set "HOME=%CD%"
-          set CL_ARCH=${{ fromJson('{ "x86": "amd64_x86", "x64": "amd64" }')[matrix.arch] }}
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %CL_ARCH%
-          C:\msys64\usr\bin\bash.exe --login -c "make package"
-      - name: Run the testsuite
-        shell: cmd
+          make package
+          make check
+      - name: Does it work sans msys2?
         run: |
-          set "HOME=%CD%"
-          set CL_ARCH=${{ fromJson('{ "x86": "amd64_x86", "x64": "amd64" }')[matrix.arch] }}
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %CL_ARCH%
-          C:\msys64\usr\bin\bash.exe --login -c "make check"
+          C:\wasi-sdk\bin\clang.exe --version
+          C:\wasi-sdk\bin\llvm-ar.exe --version
+          C:\wasi-sdk\bin\wasm-ld.exe --version
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           # Upload the dist folder. Give it a name according to the OS it was built for.
           name: ${{ format( 'dist-windows-latest-{0}', matrix.arch) }}

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ build/llvm.BUILT:
 	mkdir -p build/llvm
 	cd build/llvm && cmake -G Ninja \
 		-DCMAKE_BUILD_TYPE=MinSizeRel \
+		-DLLVM_ENABLE_TERMINFO=OFF \
+		-DLLVM_ENABLE_ZLIB=OFF \
+		-DLLVM_ENABLE_ZSTD=OFF \
+		-DLLVM_STATIC_LINK_CXX_STDLIB=ON \
 		-DCMAKE_INSTALL_PREFIX=$(PREFIX) \
 		-DLLVM_TARGETS_TO_BUILD=WebAssembly \
 		-DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-wasi \


### PR DESCRIPTION
Closes #264.

Note: still a WIP, will undraft and ping for review after:

- [x] Both x64/x86 builds are ready
- [x] There's basic testing that msys2 dll dependencies don't leak. `make check` won't serve this purpose since it needs to be run in a msys2 shell, for now I believe `clang --version` and `wasm-ld --version` should suffice since they are the largest executables anyway.