### PR TITLE
Enable ccache for CI builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 # Our docker builds do not require the submodule sources so exclude them as
 # they can be very big.
 /src
+.git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,17 +20,35 @@ jobs:
           - ubuntu-latest
           - macos-latest
     steps:
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/ccache
+          # Bump the prefix number to evict all previous caches and
+          # enforce a clean build, in the unlikely case that some
+          # weird build error occur and ccache becomes a potential
+          # suspect.
+          key: 0-cache-ubuntu-latest-${{ github.run_id }}
+          restore-keys: |
+            0-cache-ubuntu-latest
+        if: matrix.os == 'ubuntu-latest'
+      - uses: actions/cache@v3
+        with:
+          path: ~/Library/Caches/ccache
+          key: 0-cache-macos-latest-${{ github.run_id }}
+          restore-keys: |
+            0-cache-macos-latest
+        if: matrix.os == 'macos-latest'
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - name: Install ninja (macOS)
-        run: brew install ninja
+      - name: Install ccache, ninja (macOS)
+        run: brew install ccache ninja
         if: matrix.os == 'macos-latest'
-      - name: Install ninja (Linux)
-        run: sudo apt install ninja-build
+      - name: Install ccache, ninja (Linux)
+        run: sudo apt install ccache ninja-build
         if: matrix.os == 'ubuntu-latest'
       - name: Build
-        run: NINJA_FLAGS=-v make package
+        run: NINJA_FLAGS=-v make package LLVM_CMAKE_FLAGS=-DLLVM_CCACHE_BUILD=ON
         shell: bash
       - name: Run the testsuite
         run: NINJA_FLAGS=-v make check
@@ -55,11 +73,18 @@ jobs:
             sys: clang32
             env: clang-i686
     steps:
+      - uses: actions/cache@v3
+        with:
+          path: ~/AppData/Local/ccache
+          key: 0-${{ format( 'cache-windows-latest-{0}', matrix.arch) }}-${{ github.run_id }}
+          restore-keys: |
+            0-${{ format( 'cache-windows-latest-{0}', matrix.arch) }}
       - uses: msys2/setup-msys2@v2
         with:
           install: >-
             base-devel
             git
+            mingw-w64-${{ matrix.env }}-ccache
             mingw-w64-${{ matrix.env }}-cmake
             mingw-w64-${{ matrix.env }}-ninja
             mingw-w64-${{ matrix.env }}-toolchain
@@ -73,7 +98,7 @@ jobs:
       - name: Build
         shell: msys2 {0}
         run: |
-          make package
+          make package LLVM_CMAKE_FLAGS=-DLLVM_CCACHE_BUILD=ON
           make check
       - name: Does it work sans msys2?
         run: |
@@ -91,6 +116,13 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/cache@v3
+        with:
+          path: ~/.ccache
+          key: 0-cache-ubuntu-bionic-${{ github.run_id }}
+          restore-keys: |
+            0-cache-ubuntu-bionic
+
       - uses: actions/checkout@v1
         with:
           submodules: true
@@ -121,7 +153,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           # Upload the dist folder. Give it a name according to the OS it was built for.
-          name: dist-ubuntu-xenial
+          name: dist-ubuntu-bionic
           path: dist
 
       - name: Build and push wasi-sdk docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
+        ccache \
         curl \
         ca-certificates \
         build-essential \
@@ -15,9 +16,9 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sSLO https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1-linux-x86_64.tar.gz \
-  && tar xf cmake-3.20.1-linux-x86_64.tar.gz \
-  && rm cmake-3.20.1-linux-x86_64.tar.gz \
+RUN curl -sSLO https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.tar.gz \
+  && tar xf cmake-3.25.1-linux-x86_64.tar.gz \
+  && rm cmake-3.25.1-linux-x86_64.tar.gz \
   && mkdir -p /opt \
-  && mv cmake-3.20.1-linux-x86_64 /opt/cmake
+  && mv cmake-3.25.1-linux-x86_64 /opt/cmake
 ENV PATH /opt/cmake/bin:$PATH

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ build/llvm.BUILT:
 		     -DDEFAULT_SYSROOT=$(PREFIX)/share/wasi-sysroot) \
 		-DLLVM_INSTALL_BINUTILS_SYMLINKS=TRUE \
 		-DLLVM_ENABLE_LIBXML2=OFF \
+		$(LLVM_CMAKE_FLAGS) \
 		$(LLVM_PROJ_DIR)/llvm
 	DESTDIR=$(DESTDIR) ninja $(NINJA_FLAGS) -C build/llvm \
 		install-clang \

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,6 +1,7 @@
-#!/usr/bin/env sh
-set -e
-echo "Building the docker"
+#!/bin/sh
+set -ex
+echo "Building the docker image"
 docker build -t wasi-sdk-builder:latest .
-echo "Building the package in docker"
-docker run --mount type=bind,src=$PWD,target=/workspace -e NINJA_FLAGS=-v --workdir /workspace wasi-sdk-builder:latest make package
+echo "Building the package in docker image"
+mkdir -p ~/.ccache
+docker run --rm -v "$PWD":/workspace -v ~/.ccache:/root/.ccache -e NINJA_FLAGS=-v --workdir /workspace --tmpfs /tmp:exec wasi-sdk-builder:latest make package LLVM_CMAKE_FLAGS=-DLLVM_CCACHE_BUILD=ON


### PR DESCRIPTION
This PR enables `ccache` for LLVM in CI, and shall speed up building processes for subsequent PRs in this repo.