### PR TITLE
Run tests under wasmtime as part of the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,8 @@ jobs:
           restore-keys: |
             0-cache-macos-latest
         if: matrix.os == 'macos-latest'
+      - name: Install wasmtime for tests
+        run: curl -f -L --retry 5 https://wasmtime.dev/install.sh | bash -s -- --version v2.0.2
       - uses: actions/checkout@v1
         with:
           submodules: true
@@ -51,7 +53,7 @@ jobs:
         run: NINJA_FLAGS=-v make package LLVM_CMAKE_FLAGS=-DLLVM_CCACHE_BUILD=ON
         shell: bash
       - name: Run the testsuite
-        run: NINJA_FLAGS=-v make check
+        run: NINJA_FLAGS=-v make check RUNTIME=~/.wasmtime/bin/wasmtime
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ default: build
 check:
 	CC="clang --sysroot=$(BUILD_PREFIX)/share/wasi-sysroot" \
 	CXX="clang++ --sysroot=$(BUILD_PREFIX)/share/wasi-sysroot -fno-exceptions" \
-	PATH="$(PATH_PREFIX)/bin:$$PATH" tests/run.sh
+	PATH="$(PATH_PREFIX)/bin:$$PATH" tests/run.sh $(RUNTIME)
 
 clean:
 	rm -rf build $(DESTDIR)

--- a/tests/general/abort.c.stderr.expected
+++ b/tests/general/abort.c.stderr.expected
@@ -1,6 +1,6 @@
 Error: failed to run main module `abort.c.---.wasm`
 
 Caused by:
-    0: failed to invoke `_start`
-    1: wasm trap: unreachable, source location: @----
+    0: failed to invoke command default
+    1: wasm trap: wasm `unreachable` instruction executed
        wasm backtrace:

--- a/tests/general/assert-fail.c.stderr.expected
+++ b/tests/general/assert-fail.c.stderr.expected
@@ -2,6 +2,6 @@ Assertion failed: false (assert-fail.c: main: 5)
 Error: failed to run main module `assert-fail.c.---.wasm`
 
 Caused by:
-    0: failed to invoke `_start`
-    1: wasm trap: unreachable, source location: @----
+    0: failed to invoke command default
+    1: wasm trap: wasm `unreachable` instruction executed
        wasm backtrace:

--- a/tests/general/sigabrt.c.stderr.expected
+++ b/tests/general/sigabrt.c.stderr.expected
@@ -1,8 +1,6 @@
 raising SIGABRT...
-Program recieved fatal signal: Aborted
+Program received fatal signal: Aborted
 Error: failed to run main module `sigabrt.c.---.wasm`
 
 Caused by:
-    0: failed to invoke `_start`
-    1: wasm trap: unreachable, source location: @----
-       wasm backtrace:
+    0: failed to invoke command default


### PR DESCRIPTION
With approval from @sbc100, this is a rework of #144. It's checked in x64 linux/macos pipelines. Also contains minor fixes in the expected files.

We use `wasmtime-2.0.2` since it suffices for the time being (no fancy wasm extensions in our sysroot for now), and the error messages in later versions of `wasmtime` contain indeterministic addresses which makes comparison harder.