### PR TITLE
Avoid unnecessary git checkout overhead

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,15 @@ jobs:
         if: matrix.os == 'macos-latest'
       - name: Install wasmtime for tests
         run: curl -f -L --retry 5 https://wasmtime.dev/install.sh | bash -s -- --version v2.0.2
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
-          submodules: true
+          fetch-depth: 0
+      # We can't use `--depth 1` here sadly because the GNU config
+      # submodule is not pinned to a particular tag/branch. Please
+      # bump depth (or even better, the submodule), in case of "error:
+      # Server does not allow request for unadvertised object" in the
+      # future.
+      - run: git submodule update --init --depth 16 --jobs 3
       - name: Install ccache, ninja (macOS)
         run: brew install ccache ninja
         if: matrix.os == 'macos-latest'
@@ -96,7 +102,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
+      - run: git submodule update --init --depth 16 --jobs 3
       - name: Build
         shell: msys2 {0}
         run: |
@@ -125,9 +131,11 @@ jobs:
           restore-keys: |
             0-cache-ubuntu-bionic
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
-          submodules: true
+          fetch-depth: 0
+
+      - run: git submodule update --init --depth 16 --jobs 3
 
       - uses: docker/login-action@v2
         with:


### PR DESCRIPTION
The git checkout step in the current CI pipelines are pretty slow. The overhead mainly comes from the `llvm-project` submodule, however, we only need a shallow checkout of it, and full checkout with all tags is only needed for `wasi-sdk` parent repo. This PR shall further speed up all CI pipelines.