### PR TITLE
Add the `wasm32-wasi-pthread` output to the sysroot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,12 @@ build/wasi-libc.BUILT: build/llvm.BUILT
 		AR=$(BUILD_PREFIX)/bin/llvm-ar \
 		NM=$(BUILD_PREFIX)/bin/llvm-nm \
 		SYSROOT=$(BUILD_PREFIX)/share/wasi-sysroot
+	$(MAKE) -C $(ROOT_DIR)/src/wasi-libc \
+		CC=$(BUILD_PREFIX)/bin/clang \
+		AR=$(BUILD_PREFIX)/bin/llvm-ar \
+		NM=$(BUILD_PREFIX)/bin/llvm-nm \
+		SYSROOT=$(BUILD_PREFIX)/share/wasi-sysroot \
+		THREAD_MODEL=posix
 	touch build/wasi-libc.BUILT
 
 build/compiler-rt.BUILT: build/llvm.BUILT build/wasi-libc.BUILT


### PR DESCRIPTION
Now that the `wasm32-wasi-pthread` target in wasi-libc has been worked on for some amount of time, this change allows it to be released as a part of wasi-sdk packages. It should be noted somewhere (a compiler warning? README?) that this new target is not entirely stable, but that can be added as a follow-on commit. This change is mainly focused on ensuring that the build artifacts contain the new objects.