### PR TITLE
Only push docker image on push or tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,7 +171,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I noticed workflows are manually run pretty often on non-main branch like this one, which is populating github packages with the WIP code.

https://github.com/WebAssembly/wasi-sdk/actions/runs/3895139484

Presumably it's fine to not push the docker image on a manual run anyways, alternatively I could filter on ref_type != tag && ref_name == main if that seems better.