### PR TITLE
WASI support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
-	url = https://github.com/llvm/llvm-project
+	url = https://github.com/turbolent/llvm-project
 [submodule "src/wasi-libc"]
 	path = src/wasi-libc
 	url = https://github.com/CraneStation/wasi-libc


### PR DESCRIPTION
A few years ago, @binji ported LLVM/Clang 8 to WebAssembly/WASI: https://github.com/binji/wasm-clang (https://github.com/binji/llvm-project/releases/tag/wasm-bin-3)

This is extremely useful, as it allows bringing a modern compiler to many old systems, e.g. via wasm2c and https://github.com/turbolent/w2c2.

Ever since WASI SDK was released, I hoped that we could have a "self-hosting" build of it, i.e. WASI SDK compiled to WASI.

I "re-applied" Ben's changes on top of LLVM 15, the version that WASI SDK 19 uses. Unlike the original changes, I simply used the `__wasi__` define, and did not change wasi libc / libcxx -- according to Ben, he faked threading support. Instead, I opted for also adjusting the code that relies on threading support and related data structures (mutex, conditional variables, etc.).

Diff: https://github.com/turbolent/llvm-project/compare/8dfdcc7b7bf66834a761bd8de445840ef68e4d1a...8e9c5068416bd9ca1144fa2fb659636b13bd4f60

As you can see, there were not too many changes needed to get it to compile, however, the changes are hacky at times.
I hope that with the upcoming threading support of WASI / WASI SDK, it should be possible to re-enable much of the threading related code in LLVM.

I have not tested the resulting binaries of clang and wasm-ld too much, but they are able to compile a simple hello world program.

I'm opening this PR as a draft, as I would like to get some feedback and also this allows me to share the port with e.g. the [llvmbox project](https://github.com/rsms/llvmbox).