### PR TITLE
tests: use latest wasmtime for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
             0-cache-macos-latest
         if: matrix.os == 'macos-latest'
       - name: Install wasmtime for tests
-        run: curl -f -L --retry 5 https://wasmtime.dev/install.sh | bash -s -- --version v2.0.2
+        run: curl -f -L --retry 5 https://wasmtime.dev/install.sh | bash -s -- --version v8.0.1
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/tests/general/abort.c.stderr.expected
+++ b/tests/general/abort.c.stderr.expected
@@ -2,5 +2,5 @@ Error: failed to run main module `abort.c.---.wasm`
 
 Caused by:
     0: failed to invoke command default
-    1: wasm trap: wasm `unreachable` instruction executed
-       wasm backtrace:
+    1: error while executing at wasm backtrace:
+    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/abort.c.stderr.expected.filter
+++ b/tests/general/abort.c.stderr.expected.filter
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 cat \
     | sed -e 's/main module `abort\.c\.[^`]*\.wasm`/main module `abort.c.---.wasm`/' \
-    | sed -e 's/source location: @[[:xdigit:]]*$/source location: @----/' \
-    | head -n 6
+    | sed -E '/0x[[:xdigit:]]+/d'

--- a/tests/general/assert-fail.c.stderr.expected
+++ b/tests/general/assert-fail.c.stderr.expected
@@ -3,5 +3,5 @@ Error: failed to run main module `assert-fail.c.---.wasm`
 
 Caused by:
     0: failed to invoke command default
-    1: wasm trap: wasm `unreachable` instruction executed
-       wasm backtrace:
+    1: error while executing at wasm backtrace:
+    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/assert-fail.c.stderr.expected.filter
+++ b/tests/general/assert-fail.c.stderr.expected.filter
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 cat \
     | sed -e 's/main module `assert-fail\.c\.[^`]*\.wasm`/main module `assert-fail.c.---.wasm`/' \
-    | sed -e 's/source location: @[[:xdigit:]]*$/source location: @----/' \
-    | head -n 7
+    | sed -E '/0x[[:xdigit:]]+/d'


### PR DESCRIPTION
This patch enables using latest version of wasmtime for testing. This should also make it possible to run tests for wasm32-wasi-threads in the future.