### PR TITLE
ci: ensure `LLVM_CMAKE_FLAGS` additions are kept

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ BASH=
 endif
 
 ifeq ($(shell uname),Darwin)
-LLVM_CMAKE_FLAGS += -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+override LLVM_CMAKE_FLAGS += -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
 		    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
 endif
 


### PR DESCRIPTION
In #321, some OSX-specific `Makefile` additions to `LLVM_CMAKE_FLAGS` were skipped unless `make` is run on a Darwin OS. This allowed building wasi-sdk for aarch64. But, as reported in #336, this also broke arm64/x86_64 universal binaries that are built during CI.

The reason for this is that CI's `main.yml` overrides `LLVM_CMAKE_FLAGS` to add caching but `make` will not append to a variable set on the command line. This changes uses the `override` keyword to append to such a variable, as suggested [here].

[here]: https://www.gnu.org/software/make/manual/html_node/Override-Directive.html