### PR TITLE
Add wasi-sdk-pthread.cmake to docker image to allow enabling it with env

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ COPY --from=dist /wasi-sdk/share/wasi-sysroot/ /wasi-sysroot/
 COPY --from=dist /wasi-sysroot-clang_rt/lib/wasi /usr/lib/llvm-${LLVM_VERSION}/lib/clang/${LLVM_VERSION}/lib/wasi
 
 ADD docker/wasi-sdk.cmake /usr/share/cmake/wasi-sdk.cmake
+ADD docker/wasi-sdk-pthread.cmake /usr/share/cmake/wasi-sdk-pthread.cmake
 ENV CMAKE_TOOLCHAIN_FILE /usr/share/cmake/wasi-sdk.cmake
 ADD cmake/Platform/WASI.cmake /usr/share/cmake/Modules/Platform/WASI.cmake
 

--- a/docker/wasi-sdk-pthread.cmake
+++ b/docker/wasi-sdk-pthread.cmake
@@ -9,7 +9,14 @@ list(APPEND CMAKE_MODULE_PATH /usr/share/cmake/Modules)
 set(CMAKE_SYSTEM_NAME WASI)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR wasm32)
-set(triple wasm32-wasi)
+set(triple wasm32-wasi-threads)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+# wasi-threads requires --import-memory.
+# wasi requires --export-memory.
+# (--export-memory is implicit unless --import-memory is given)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--import-memory")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--export-memory")
 
 set(CMAKE_C_COMPILER /usr/bin/clang-$ENV{LLVM_VERSION})
 set(CMAKE_CXX_COMPILER /usr/bin/clang++-$ENV{LLVM_VERSION})


### PR DESCRIPTION
TBH, I'm not sure what to think of this change as it does seem to bring the number of cmake files in this repo to an incredible level. But the docker image is the easiest way to just try building a repo with WASI (e.g., https://github.com/abseil/abseil-cpp/pull/1509), and being able to just `export CMAKE_TOOKCHAIN_FILE=/usr/share/cmake/wasi-sdk-pthread.cmake` would be a great boon.