### PR TITLE
Do not use GNU find features on FreeBSD

### DIFF
--- a/strip_symbols.sh
+++ b/strip_symbols.sh
@@ -2,9 +2,9 @@
 set -e
 
 DIRECTORY=${1:-/opt/wasi-sdk/bin}
-if [[ "$OSTYPE" == "darwin"* ]]; then
-# macos find doesnt support -executable so we fall back on having a permission
-# bit to execute:
+if [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "freebsd"* ]]; then
+# macos and freebsd find do not support -executable so we fall back on
+# having a permission bit to execute:
 EXECUTABLES=$(find ${DIRECTORY} -type f -perm +111)
 else
 EXECUTABLES=$(find ${DIRECTORY} -type f -executable)


### PR DESCRIPTION
FreeBSD (like MacOS) does not support the `-executable` argument for `find`. This commit checks if the OS is FreeBSD, and if so, uses the same workaround as already in place on MacOS.

A more portable solution might be to test if the `-executable` flag is available, and fallback to `-perm` if not.