### PR TITLE
Enhancement of WASI_SDK_PREFIX in toolchain files

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ includes/libraries/etc. The `--sysroot=...` option is not necessary if
 `WASI_SDK_PATH` is `/opt/wasi-sdk`. For troubleshooting, one can replace the
 `--sysroot` path with a manual build of [wasi-libc].
 
+### Integrating with a CMake build system
+
+Use a toolchain file to setup the *wasi-sdk* platform.
+
+```
+$ cmake -DCMAKE_TOOLCHAIN_FILE=${WASI_SDK_PATH}/share/cmake/wasi-sdk.cmake ...
+```
+
+or the *wasi-sdk-thread* platform
+
+```
+$ cmake -DCMAKE_TOOLCHAIN_FILE=${WASI_SDK_PATH}/share/cmake/wasi-sdk-pthread.cmake ...
+```
+
 ## Notes for Autoconf
 
 [Autoconf] 2.70 now [recognizes WASI].

--- a/wasi-sdk-pthread.cmake
+++ b/wasi-sdk-pthread.cmake
@@ -21,6 +21,11 @@ else()
 	set(WASI_HOST_EXE_SUFFIX "")
 endif()
 
+# When building from source, WASI_SDK_PREFIX represents the generated directory
+if(NOT WASI_SDK_PREFIX)
+    set(WASI_SDK_PREFIX ${CMAKE_CURRENT_LIST_DIR}/../../)
+endif()
+
 set(CMAKE_C_COMPILER ${WASI_SDK_PREFIX}/bin/clang${WASI_HOST_EXE_SUFFIX})
 set(CMAKE_CXX_COMPILER ${WASI_SDK_PREFIX}/bin/clang++${WASI_HOST_EXE_SUFFIX})
 set(CMAKE_ASM_COMPILER ${WASI_SDK_PREFIX}/bin/clang${WASI_HOST_EXE_SUFFIX})

--- a/wasi-sdk.cmake
+++ b/wasi-sdk.cmake
@@ -18,6 +18,11 @@ else()
 	set(WASI_HOST_EXE_SUFFIX "")
 endif()
 
+# When building from source, WASI_SDK_PREFIX represents the generated directory
+if(NOT WASI_SDK_PREFIX)
+    set(WASI_SDK_PREFIX ${CMAKE_CURRENT_LIST_DIR}/../../)
+endif()
+
 set(CMAKE_C_COMPILER ${WASI_SDK_PREFIX}/bin/clang${WASI_HOST_EXE_SUFFIX})
 set(CMAKE_CXX_COMPILER ${WASI_SDK_PREFIX}/bin/clang++${WASI_HOST_EXE_SUFFIX})
 set(CMAKE_ASM_COMPILER ${WASI_SDK_PREFIX}/bin/clang${WASI_HOST_EXE_SUFFIX})


### PR DESCRIPTION
No need to pass `WASI_SDK_PREFIX` value from the command line. Use `CMAKE_CURRENT_LIST_DIR` to assemble the value of `WASI_SDK_PREFIX` now.