### PR TITLE
Set -fno-exceptions in CXXFLAGS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,5 +48,5 @@ ENV AR llvm-ar-${LLVM_VERSION}
 ENV RANLIB llvm-ranlib-${LLVM_VERSION}
 
 ENV CFLAGS --target=wasm32-wasi --sysroot=/wasi-sysroot
-ENV CXXFLAGS --target=wasm32-wasi --sysroot=/wasi-sysroot
+ENV CXXFLAGS --target=wasm32-wasi --sysroot=/wasi-sysroot -fno-exceptions
 ENV LDFLAGS --target=wasm32-wasi --sysroot=/wasi-sysroot

--- a/docker/wasi-sdk-pthread.cmake
+++ b/docker/wasi-sdk-pthread.cmake
@@ -28,6 +28,8 @@ set(CMAKE_CXX_COMPILER_TARGET ${triple})
 set(CMAKE_ASM_COMPILER_TARGET ${triple})
 SET(CMAKE_SYSROOT /wasi-sysroot)
 
+set(CMAKE_CXX_FLAGS_INIT "-fno-exceptions")
+
 # Don't look in the sysroot for executables to run during the build
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 # Only look in the sysroot (not in the host paths) for the rest

--- a/docker/wasi-sdk.cmake
+++ b/docker/wasi-sdk.cmake
@@ -21,6 +21,8 @@ set(CMAKE_CXX_COMPILER_TARGET ${triple})
 set(CMAKE_ASM_COMPILER_TARGET ${triple})
 SET(CMAKE_SYSROOT /wasi-sysroot)
 
+set(CMAKE_CXX_FLAGS_INIT "-fno-exceptions")
+
 # Don't look in the sysroot for executables to run during the build
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 # Only look in the sysroot (not in the host paths) for the rest

--- a/wasi-sdk-pthread.cmake
+++ b/wasi-sdk-pthread.cmake
@@ -35,6 +35,8 @@ set(CMAKE_C_COMPILER_TARGET ${triple})
 set(CMAKE_CXX_COMPILER_TARGET ${triple})
 set(CMAKE_ASM_COMPILER_TARGET ${triple})
 
+set(CMAKE_CXX_FLAGS_INIT "-fno-exceptions")
+
 # Don't look in the sysroot for executables to run during the build
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 # Only look in the sysroot (not in the host paths) for the rest

--- a/wasi-sdk.cmake
+++ b/wasi-sdk.cmake
@@ -32,6 +32,8 @@ set(CMAKE_C_COMPILER_TARGET ${triple})
 set(CMAKE_CXX_COMPILER_TARGET ${triple})
 set(CMAKE_ASM_COMPILER_TARGET ${triple})
 
+set(CMAKE_CXX_FLAGS_INIT "-fno-exceptions")
+
 # Don't look in the sysroot for executables to run during the build
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 # Only look in the sysroot (not in the host paths) for the rest


### PR DESCRIPTION
A while back, the idea to add no-exceptions to CXXFLAGS in the docker image came up but we held up to keep consistency with the cmake files

https://github.com/WebAssembly/wasi-sdk/pull/271#discussion_r1055011577

I thought it would be good to bring it up again with the cmake files also updated. AFAICT, when using wasi-sdk with C++ it almost always ends up the user's responsibility to set this as exceptions aren't supported, so it can be a bit easier by defaulting it