### PR TITLE
Build llvm with LLVM_INSTALL_TOOLCHAIN_ONLY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,31 +80,12 @@ build/llvm.BUILT:
 		          -DDEFAULT_SYSROOT=../share/wasi-sysroot, \
 			  -DDEFAULT_SYSROOT=$(PREFIX)/share/wasi-sysroot), \
 		     -DDEFAULT_SYSROOT=$(PREFIX)/share/wasi-sysroot) \
-		-DLLVM_INSTALL_BINUTILS_SYMLINKS=TRUE \
+		-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON \
+		-DLLVM_INSTALL_BINUTILS_SYMLINKS=ON \
 		-DLLVM_ENABLE_LIBXML2=OFF \
 		$(LLVM_CMAKE_FLAGS) \
 		$(LLVM_PROJ_DIR)/llvm
-	DESTDIR=$(DESTDIR) ninja $(NINJA_FLAGS) -C build/llvm \
-		install-clang \
-		install-clang-format \
-		install-clang-tidy \
-		install-clang-apply-replacements \
-		install-lld \
-		install-llvm-mc \
-		install-llvm-ranlib \
-		install-llvm-strip \
-		install-llvm-dwarfdump \
-		install-clang-resource-headers \
-		install-ar \
-		install-ranlib \
-		install-strip \
-		install-nm \
-		install-size \
-		install-strings \
-		install-objdump \
-		install-objcopy \
-		install-c++filt \
-		llvm-config
+	DESTDIR=$(DESTDIR) ninja $(NINJA_FLAGS) -C build/llvm install
 	touch build/llvm.BUILT
 
 build/wasi-libc.BUILT: build/llvm.BUILT


### PR DESCRIPTION
This means that `make install` then only installs things that are meant to be part of the public facing toolchain.

See https://llvm.org/docs/BuildingADistribution.html#difference-between-install-and-install-distribution

The list binaries that get installed now differ as follows:

```
--- old
+++ new
@@ -1,34 +1,72 @@
+addr2line
+amdgpu-arch
+analyze-build
 ar
 c++filt
 clang
 clang++
 clang-17
 clang-apply-replacements
+clang-change-namespace
+clang-check
 clang-cl
 clang-cpp
+clangd
+clang-doc
+clang-extdef-mapping
 clang-format
+clang-include-cleaner
+clang-include-fixer
+clang-linker-wrapper
+clang-move
+clang-offload-bundler
+clang-offload-packager
+clang-pseudo
+clang-query
+clang-refactor
+clang-rename
+clang-reorder-fields
+clang-scan-deps
 clang-tidy
+diagtool
+find-all-symbols
 git-clang-format
+hmaptool
+intercept-build
 ld64.lld
 ld.lld
 lld
 lld-link
 llvm-ar
+llvm-cov
 llvm-cxxfilt
-llvm-dwarfdump
-llvm-mc
+llvm-dwp
+llvm-lib
+llvm-ml
 llvm-nm
 llvm-objcopy
 llvm-objdump
+llvm-pdbutil
+llvm-profdata
 llvm-ranlib
+llvm-rc
+llvm-readobj
 llvm-size
 llvm-strings
 llvm-strip
+llvm-symbolizer
+modularize
 nm
+nvptx-arch
 objcopy
 objdump
+pp-trace
 ranlib
+readelf
 run-clang-tidy
+scan-build
+scan-build-py
+scan-view
 size
 strings
 strip
```