### PR TITLE
build and test `wasm32-wasi-preview2` target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,19 @@ jobs:
             0-cache-macos-latest
         if: matrix.os == 'macos-latest'
       - name: Install wasmtime for tests
-        run: curl -f -L --retry 5 https://wasmtime.dev/install.sh | bash -s -- --version v8.0.1
+        run: |
+          curl -f -L --retry 5 https://wasmtime.dev/install.sh | bash -s -- --version v16.0.0
+          ~/.wasmtime/bin/wasmtime --version
+          curl -f -L --retry 5  -o ~/.wasmtime/bin/wasi_snapshot_preview1.command.wasm https://github.com/bytecodealliance/wasmtime/releases/download/v16.0.0/wasi_snapshot_preview1.command.wasm
+          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+          curl -f -OL --retry 5 https://github.com/bytecodealliance/wasm-tools/releases/download/wasm-tools-1.0.54/wasm-tools-1.0.54-x86_64-linux.tar.gz
+          tar xf wasm-tools-1.0.54-x86_64-linux.tar.gz
+          cp wasm-tools-1.0.54-x86_64-linux/wasm-tools ~/.wasmtime/bin/
+          else
+          curl -f -OL --retry 5 https://github.com/bytecodealliance/wasm-tools/releases/download/wasm-tools-1.0.54/wasm-tools-1.0.54-x86_64-macos.tar.gz
+          tar xf wasm-tools-1.0.54-x86_64-macos.tar.gz
+          cp wasm-tools-1.0.54-x86_64-macos/wasm-tools ~/.wasmtime/bin/          
+          fi
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -59,7 +71,7 @@ jobs:
         run: NINJA_FLAGS=-v make package LLVM_CMAKE_FLAGS=-DLLVM_CCACHE_BUILD=ON
         shell: bash
       - name: Run the testsuite
-        run: NINJA_FLAGS=-v make check RUNTIME=~/.wasmtime/bin/wasmtime
+        run: NINJA_FLAGS=-v make check RUNTIME=~/.wasmtime/bin/wasmtime ADAPTER=~/.wasmtime/bin/wasi_snapshot_preview1.command.wasm WASM_TOOLS=~/.wasmtime/bin/wasm-tools
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,9 @@ jobs:
             0-cache-macos-latest
         if: matrix.os == 'macos-latest'
       - name: Install wasmtime for tests
+        # TODO: switch to Wasmtime 17 once it's released, which will include https://github.com/bytecodealliance/wasmtime/pull/7750
         run: |
-          curl -f -L --retry 5 https://wasmtime.dev/install.sh | bash -s -- --version v16.0.0
+          curl -f -L --retry 5 https://wasmtime.dev/install.sh | bash -s -- --version dev
           ~/.wasmtime/bin/wasmtime --version
           curl -f -L --retry 5  -o ~/.wasmtime/bin/wasi_snapshot_preview1.command.wasm https://github.com/bytecodealliance/wasmtime/releases/download/v16.0.0/wasi_snapshot_preview1.command.wasm
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then

--- a/tests/general/abort.c.wasm32-wasi-preview2.stderr.expected
+++ b/tests/general/abort.c.wasm32-wasi-preview2.stderr.expected
@@ -1,0 +1,6 @@
+Error: failed to run main module `abort.c.---.wasm`
+
+Caused by:
+    0: failed to invoke `run` function
+    1: error while executing at wasm backtrace:
+    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/assert-fail.c.wasm32-wasi-preview2.stderr.expected
+++ b/tests/general/assert-fail.c.wasm32-wasi-preview2.stderr.expected
@@ -1,0 +1,7 @@
+Assertion failed: false (assert-fail.c: main: 5)
+Error: failed to run main module `assert-fail.c.---.wasm`
+
+Caused by:
+    0: failed to invoke `run` function
+    1: error while executing at wasm backtrace:
+    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/sigabrt.c.wasm32-wasi-preview2.stderr.expected
+++ b/tests/general/sigabrt.c.wasm32-wasi-preview2.stderr.expected
@@ -1,0 +1,6 @@
+raising SIGABRT...
+Program received fatal signal: Aborted
+Error: failed to run main module `sigabrt.c.---.wasm`
+
+Caused by:
+    0: failed to invoke `run` function

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -23,8 +23,17 @@ wasi_sdk="$1"
 # Determine the wasm runtime to use, if one is provided.
 if [ $# -gt 1 ]; then
     runwasi="$2"
+    if [ $# -gt 3 ]; then
+        adapter="$3"
+        wasm_tools="$4"
+    else
+        adapter=""
+        wasm_tools=""
+    fi
 else
     runwasi=""
+    adapter=""
+    wasm_tools=""
 fi
 
 testdir=$(dirname $0)
@@ -35,34 +44,39 @@ echo $CC
 echo $CXX
 echo "SDK: $wasi_sdk"
 
-cd $testdir/compile-only
-for options in -O0 -O2 "-O2 -flto"; do
-    echo "===== Testing compile-only with $options ====="
-    for file in *.c; do
-        echo "Testing compile-only $file..."
-        ../testcase.sh "" "$CC" "$options" "$file"
+# TODO: `wasm32-wasi-threads` should be in this list, but as of this writing the
+# `signal.c` test is failing due to https://github.com/bytecodealliance/wasmtime/issues/7745
+for target in wasm32-wasi-preview2 wasm32-wasi; do
+    echo "===== Testing target $target ====="
+    cd $testdir/compile-only
+    for options in -O0 -O2 "-O2 -flto"; do
+        echo "===== Testing compile-only with $options ====="
+        for file in *.c; do
+            echo "Testing compile-only $file..."
+            ../testcase.sh "$target" "" "" "" "$CC" "$options" "$file"
+        done
+        for file in *.cc; do
+            echo "Testing compile-only $file..."
+            ../testcase.sh "$target" "" "" "" "$CXX" "$options" "$file"
+        done
     done
-    for file in *.cc; do
-        echo "Testing compile-only $file..."
-        ../testcase.sh "" "$CXX" "$options" "$file"
+    cd - >/dev/null
+    
+    cd $testdir/general
+    for options in -O0 -O2 "-O2 -flto"; do
+        echo "===== Testing with $options ====="
+        for file in *.c; do
+            echo "Testing $file..."
+            ../testcase.sh "$target" "$runwasi" "$adapter" "$wasm_tools" "$CC" "$options" "$file"
+        done
+        for file in *.cc; do
+            echo "Testing $file..."
+            ../testcase.sh "$target" "$runwasi" "$adapter" "$wasm_tools" "$CXX" "$options" "$file"
+        done
     done
+    cd - >/dev/null
 done
-cd - >/dev/null
-
-cd $testdir/general
-for options in -O0 -O2 "-O2 -flto"; do
-    echo "===== Testing with $options ====="
-    for file in *.c; do
-        echo "Testing $file..."
-        ../testcase.sh "$runwasi" "$CC" "$options" "$file"
-    done
-    for file in *.cc; do
-        echo "Testing $file..."
-        ../testcase.sh "$runwasi" "$CXX" "$options" "$file"
-    done
-done
-cd - >/dev/null
-
+    
 # Test cmake build system for wasi-sdk
 test_cmake() {
     local option

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -44,9 +44,7 @@ echo $CC
 echo $CXX
 echo "SDK: $wasi_sdk"
 
-# TODO: `wasm32-wasi-threads` should be in this list, but as of this writing the
-# `signal.c` test is failing due to https://github.com/bytecodealliance/wasmtime/issues/7745
-for target in wasm32-wasi-preview2 wasm32-wasi; do
+for target in wasm32-wasi wasm32-wasi-threads wasm32-wasi-preview2; do
     echo "===== Testing target $target ====="
     cd $testdir/compile-only
     for options in -O0 -O2 "-O2 -flto"; do

--- a/tests/testcase.sh
+++ b/tests/testcase.sh
@@ -28,10 +28,16 @@ else
     file_options=
 fi
 
+if [ "$target" == "wasm32-wasi-threads" ]; then
+    pthread_options="-pthread"
+else
+    pthread_options=
+fi
+
 echo "Testing $input..."
 
 # Compile the testcase.
-$compiler --target=$target $options $file_options "$input" -o "$wasm"
+$compiler --target=$target $pthread_options $options $file_options "$input" -o "$wasm"
 
 # If we don't have a runwasi command, we're just doing compile-only testing.
 if [ "$runwasi" == "" ]; then


### PR DESCRIPTION
This updates `wasi-libc` to include
https://github.com/WebAssembly/wasi-libc/pull/457, which adds preliminary support for the new `wasm32-wasi-preview2` target.

It also adds support for testing the new target using Wasmtime 16.0.0 and `wit-component`.  Note that Wasmtime produces different output when reporting errors for Preview 2 components than it does for Preview 1 modules, so I've added a few .expected files specific to Preview 2.