### PR TITLE
Use `apt-get autoremove` to clean up dependencies in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
 \
     apt-get update && \
     apt-get install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION} cmake ninja-build make autoconf autogen automake libtool && \
-    apt-get remove -y curl gnupg && \
+    apt-get autoremove -y curl gnupg && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=dist /wasi-sdk/share/wasi-sysroot/ /wasi-sysroot/


### PR DESCRIPTION
Currently there are left-over packages remain in the docker image:

```
The following packages were automatically installed and are no longer required:
    dirmngr gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server
    gpgconf gpgsm libassuan0 libksba8 libnpth0 pinentry-curses
Use 'apt autoremove' to remove them.
```