### PR TITLE
Start renaming preview1 to p1 and preview2 to p2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,8 @@ build/compiler-rt.BUILT: build/llvm.BUILT
 	DESTDIR=$(DESTDIR) ninja $(NINJA_FLAGS) -C build/compiler-rt install
 	# Install clang-provided headers.
 	cp -R $(ROOT_DIR)/build/llvm/lib/clang $(BUILD_PREFIX)/lib/
-	cp -R $(BUILD_PREFIX)/lib/clang/17/lib/wasi $(BUILD_PREFIX)/lib/clang/17/lib/wasip1
-	cp -R $(BUILD_PREFIX)/lib/clang/17/lib/wasi $(BUILD_PREFIX)/lib/clang/17/lib/wasip2
+	cp -R $(BUILD_PREFIX)/lib/clang/$(CLANG_VERSION)/lib/wasi $(BUILD_PREFIX)/lib/clang/$(CLANG_VERSION)/lib/wasip1
+	cp -R $(BUILD_PREFIX)/lib/clang/$(CLANG_VERSION)/lib/wasi $(BUILD_PREFIX)/lib/clang/$(CLANG_VERSION)/lib/wasip2
 	touch build/compiler-rt.BUILT
 
 # Flags for libcxx and libcxxabi.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -44,7 +44,7 @@ echo $CC
 echo $CXX
 echo "SDK: $wasi_sdk"
 
-for target in wasm32-wasi wasm32-wasi-threads wasm32-wasi-preview2; do
+for target in wasm32-wasi wasm32-wasip1 wasm32-wasi-threads wasm32-wasip1-threads wasm32-wasip2; do
     echo "===== Testing target $target ====="
     cd $testdir/compile-only
     for options in -O0 -O2 "-O2 -flto"; do

--- a/tests/testcase.sh
+++ b/tests/testcase.sh
@@ -28,7 +28,7 @@ else
     file_options=
 fi
 
-if [ "$target" == "wasm32-wasi-threads" ]; then
+if echo "$target" | grep -q -- '-threads$'; then
     pthread_options="-pthread"
 else
     pthread_options=


### PR DESCRIPTION
This commit is a reflection of WebAssembly/wasi-libc#478 into this repository where a few changes are happening:

* A new `wasm32-wasip1` sysroot is prepared matching `wasm32-wasi`
* A new `wasm32-wasip1-threads` sysroot is prepared matching `wasm32-wasi-threads`
* The `wasm32-wasi-preview2` target is renamed `wasm32-wasip2`

I've done a bit of makefile refactoring to deduplicate things a bit now that there's a number of targets being built.

The long-term goal would be to remove the `wasm32-wasi` and `wasm32-wasip1-threads` targets, but that's not proposed just yet at this time.