### PR TITLE
Refactor installation of wasmtime/wasm-tools on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,21 +38,16 @@ jobs:
           restore-keys: |
             0-cache-macos-latest
         if: matrix.os == 'macos-latest'
-      - name: Install wasmtime for tests
-        # TODO: switch to Wasmtime 17 once it's released, which will include https://github.com/bytecodealliance/wasmtime/pull/7750
-        run: |
-          curl -f -L --retry 5 https://wasmtime.dev/install.sh | bash -s -- --version dev
-          ~/.wasmtime/bin/wasmtime --version
-          curl -f -L --retry 5  -o ~/.wasmtime/bin/wasi_snapshot_preview1.command.wasm https://github.com/bytecodealliance/wasmtime/releases/download/dev/wasi_snapshot_preview1.command.wasm
-          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-          curl -f -OL --retry 5 https://github.com/bytecodealliance/wasm-tools/releases/download/wasm-tools-1.0.54/wasm-tools-1.0.54-x86_64-linux.tar.gz
-          tar xf wasm-tools-1.0.54-x86_64-linux.tar.gz
-          cp wasm-tools-1.0.54-x86_64-linux/wasm-tools ~/.wasmtime/bin/
-          else
-          curl -f -OL --retry 5 https://github.com/bytecodealliance/wasm-tools/releases/download/wasm-tools-1.0.54/wasm-tools-1.0.54-x86_64-macos.tar.gz
-          tar xf wasm-tools-1.0.54-x86_64-macos.tar.gz
-          cp wasm-tools-1.0.54-x86_64-macos/wasm-tools ~/.wasmtime/bin/          
-          fi
+      - name: Setup `wasmtime`
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+        with:
+          version: "18.0.2"
+      - name: Setup `wasm-tools`
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
+        with:
+          version: "1.201.0"
+      - name: Download latest command adapter
+        run: curl -f -L --retry 5 -o ~/.wasmtime/bin/wasi_snapshot_preview1.command.wasm https://github.com/bytecodealliance/wasmtime/releases/download/v18.0.2/wasi_snapshot_preview1.command.wasm
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
We've got official actions for installation Wasmtime and wasm-tools in the bytecodealliance organization which should help make this installation step a bit more readable.