### PR TITLE
Allow Docker to run locally in more places

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -2,6 +2,12 @@
 set -ex
 echo "Building the docker image"
 docker build -t wasi-sdk-builder:latest .
+
+if ! git config safe.directory | grep /workspace; then
+    echo "Setting up Git safe directory"
+    git config --add safe.directory /workspace
+fi
+
 echo "Building the package in docker image"
 mkdir -p ~/.ccache
-docker run --rm -v "$PWD":/workspace -v ~/.ccache:/root/.ccache -e NINJA_FLAGS=-v --workdir /workspace --tmpfs /tmp:exec wasi-sdk-builder:latest make package LLVM_CMAKE_FLAGS=-DLLVM_CCACHE_BUILD=ON
+docker run --rm -v "$PWD":/workspace:Z -v ~/.ccache:/root/.ccache:Z -e NINJA_FLAGS=-v --workdir /workspace --tmpfs /tmp:exec wasi-sdk-builder:latest make package LLVM_CMAKE_FLAGS=-DLLVM_CCACHE_BUILD=ON


### PR DESCRIPTION
These are the changes I had to make to get the `docker_build.sh` script to run locally on my Fedora 39 machine with Docker 24.0.5. I believe the main issue here is one of permissions, which may not be present in CI due to them being elevated (?).