### PR TITLE
Link LLVM-based tools dynamically to LLVM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - debug-a-bit
   pull_request:
   workflow_dispatch:
 
@@ -22,6 +23,7 @@ jobs:
     steps:
       - uses: actions/cache@v4
         with:
+          save-always: true
           path: ~/.cache/ccache
           # Bump the prefix number to evict all previous caches and
           # enforce a clean build, in the unlikely case that some
@@ -33,6 +35,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       - uses: actions/cache@v4
         with:
+          save-always: true
           path: ~/Library/Caches/ccache
           key: 0-cache-macos-latest-${{ github.run_id }}
           restore-keys: |
@@ -91,6 +94,7 @@ jobs:
     steps:
       - uses: actions/cache@v4
         with:
+          save-always: true
           path: ~/AppData/Local/ccache
           key: 0-${{ format( 'cache-windows-latest-{0}', matrix.arch) }}-${{ github.run_id }}
           restore-keys: |
@@ -114,7 +118,7 @@ jobs:
       - name: Build
         shell: msys2 {0}
         run: |
-          make package LLVM_CMAKE_FLAGS=-DLLVM_CCACHE_BUILD=ON
+          NINJA_FLAGS=-v make package LLVM_CMAKE_FLAGS=-DLLVM_CCACHE_BUILD=ON
           make check
       - name: Does it work sans msys2?
         run: |
@@ -134,6 +138,7 @@ jobs:
     steps:
       - uses: actions/cache@v4
         with:
+          save-always: true
           path: ~/.ccache
           key: 0-cache-ubuntu-bionic-${{ github.run_id }}
           restore-keys: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,21 @@ jobs:
           C:\wasi-sdk\bin\clang.exe --version
           C:\wasi-sdk\bin\llvm-ar.exe --version
           C:\wasi-sdk\bin\wasm-ld.exe --version
+      - if: always()
+        shell: msys2 {0}
+        run: find build/compiler-rt
+      - if: always()
+        shell: msys2 {0}
+        run: find C:/wasi-sdk
+      - if: always()
+        shell: msys2 {0}
+        run: ls -l C:/wasi-sdk
+      - if: always()
+        shell: msys2 {0}
+        run: find /c/wasi-sdk
+      - if: always()
+        shell: msys2 {0}
+        run: ls -l /c/wasi-sdk
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ build/llvm.BUILT:
 		-DCLANG_LINKS_TO_CREATE="$(call join-with,;,$(CLANG_LINKS_TO_CREATE))" \
 		-DCMAKE_BUILD_TYPE=MinSizeRel \
 		-DLLVM_ENABLE_TERMINFO=OFF \
+		-DLLVM_LINK_LLVM_DYLIB=ON \
+		-DLLVM_VERSION_SUFFIX=-wasi-sdk \
 		-DLLVM_ENABLE_ZLIB=OFF \
 		-DLLVM_ENABLE_ZSTD=OFF \
 		-DLLVM_STATIC_LINK_CXX_STDLIB=ON \
@@ -118,6 +120,8 @@ build/llvm.BUILT:
 		install-objdump \
 		install-objcopy \
 		install-c++filt \
+		install-LLVM \
+		install-clang-cpp \
 		llvm-config
 	touch build/llvm.BUILT
 


### PR DESCRIPTION
I noticed that #388 increased the size of the Windows distribution by 200M+ and my guess for that is that all the symlinks which point to clang get copied as real files (due to symlinks not always working on Windows). To help counteract that this commit enables the `LLVM_LINK_LLVM_DYLIB=ON` option when building LLVM and Clang. That should build a `libLLVM.so` which helps reduce the size of all the tools since they no longer all statically link LLVM. Locally the size of a full build is ~100M less as a result of this change. On Windows where all the binaries are copied around it should hopefully help much more.

I've additionally taken a leaf out of rust-lang/rust's book of building LLVM to pass the `LLVM_VERSION_SUFFIX` option here too. That I believe helps avoid `libLLVM.so` conflicting with a system-installed `libLLVM.so` by accident by ensuring there's a suffix present on the binaries built for wasi-sdk.