### PR TITLE
Fix a flaky test failure in getentropy.c

### DIFF
--- a/tests/general/getentropy.c
+++ b/tests/general/getentropy.c
@@ -1,17 +1,19 @@
 #include <assert.h>
 #include <unistd.h>
+#include <stdbool.h>
 
 int main() {
   char buf[256] = {0};
   int ret = getentropy(buf, 256);
   assert(ret == 0);
 
-  int sum = 0;
+  bool something_nonzero = false;
   for (int i = 0; i < 256; i++) {
-    sum += buf[i];
+    if (buf[i] != 0)
+      something_nonzero = true;
   }
 
-  assert(sum != 0);
+  assert(something_nonzero);
 
   return 0;
 }


### PR DESCRIPTION
This test looks to be asserting that `getrandom` never returns 256 consecutive zeros, but the way it's asserting that is summing up the bytes and asserting the sum is nonzero. Due to this being a signed addition, however, it's possible for the bytes to be nonzero and still trigger the assert. Locally running this test in a loop took 30 or so seconds before it triggered a failure.

I've updated the test to instead hunt for any entry which is not equal to zero and then assert that something is not zero.