### PR TITLE
update wasi-libc and fix out-of-date tests

### DIFF
--- a/tests/general/abort.c.wasm32-wasi.stderr.expected
+++ b/tests/general/abort.c.wasm32-wasi.stderr.expected
@@ -1,0 +1,6 @@
+Error: failed to run main module `abort.c.---.wasm`
+
+Caused by:
+    0: failed to invoke command default
+    1: error while executing at wasm backtrace:
+    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/abort.c.wasm32-wasip2.stderr.expected
+++ b/tests/general/abort.c.wasm32-wasip2.stderr.expected
@@ -1,0 +1,6 @@
+Error: failed to run main module `abort.c.---.wasm`
+
+Caused by:
+    0: failed to invoke `run` function
+    1: error while executing at wasm backtrace:
+    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/assert-fail.c.wasm32-wasip2.stderr.expected
+++ b/tests/general/assert-fail.c.wasm32-wasip2.stderr.expected
@@ -1,0 +1,7 @@
+Assertion failed: false (assert-fail.c: main: 5)
+Error: failed to run main module `assert-fail.c.---.wasm`
+
+Caused by:
+    0: failed to invoke `run` function
+    1: error while executing at wasm backtrace:
+    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/sigabrt.c.wasm32-wasip2.stderr.expected
+++ b/tests/general/sigabrt.c.wasm32-wasip2.stderr.expected
@@ -1,0 +1,6 @@
+raising SIGABRT...
+Program received fatal signal: Aborted
+Error: failed to run main module `sigabrt.c.---.wasm`
+
+Caused by:
+    0: failed to invoke `run` function

--- a/tests/testcase.sh
+++ b/tests/testcase.sh
@@ -44,7 +44,7 @@ if [ "$runwasi" == "" ]; then
     exit 0
 fi
 
-if [ "$target" == "wasm32-wasi-preview2" -a -n "$adapter" -a -n "$wasm_tools" ]; then
+if [ "$target" == "wasm32-wasip2" -a -n "$adapter" -a -n "$wasm_tools" ]; then
     "$wasm_tools" component new --adapt "$adapter" "$wasm" -o "$wasm"
     run_args="--wasm component-model"
 fi


### PR DESCRIPTION
This updates the `wasi-libc` submodule to point to `main` and also:

- update tests/testcase.sh to use new wasm32-wasip2 target name
- update various tests/**/*.expected files to match Wasmtime output