### PR TITLE
Force-fetch tags in CI to fix `git describe`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - run: git fetch --tags --force
+        name: Force-fetch tags to work around actions/checkout#290
       # We can't use `--depth 1` here sadly because the GNU config
       # submodule is not pinned to a particular tag/branch. Please
       # bump depth (or even better, the submodule), in case of "error:
@@ -105,6 +107,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - run: git fetch --tags --force
+        name: Force-fetch tags to work around actions/checkout#290
       - run: git submodule update --init --depth 32 --jobs 3
       - name: Build
         shell: msys2 {0}
@@ -137,6 +141,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - run: git fetch --tags --force
+        name: Force-fetch tags to work around actions/checkout#290
 
       - run: git submodule update --init --depth 32 --jobs 3
 


### PR DESCRIPTION
My release attempt in #408 did not go well because the release artifacts were not named correctly. This fixes an issue described by actions/checkout#290 where checkouts of annotated tags overwrite the annotation which breaks `git describe`. That means that version detection is broken in CI during releases which causes artifacts to have the wrong information.

This applies the workaround described in that issue to `git fetch --tags --force` after the checkout step to undo the overwrite done in the checkout step.