### PR TITLE
Remove cmake_minimum_required from toolchain files

### DIFF
--- a/wasi-sdk-p2.cmake
+++ b/wasi-sdk-p2.cmake
@@ -1,8 +1,5 @@
 # Cmake toolchain description file for the Makefile
 
-# This is arbitrary, AFAIK, for now.
-cmake_minimum_required(VERSION 3.5.0)
-
 # Until Platform/WASI.cmake is upstream we need to inject the path to it
 # into CMAKE_MODULE_PATH.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/wasi-sdk-pthread.cmake
+++ b/wasi-sdk-pthread.cmake
@@ -1,8 +1,5 @@
 # Cmake toolchain description file for the Makefile
 
-# This is arbitrary, AFAIK, for now.
-cmake_minimum_required(VERSION 3.4.0)
-
 set(CMAKE_SYSTEM_NAME WASI)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR wasm32)

--- a/wasi-sdk.cmake
+++ b/wasi-sdk.cmake
@@ -1,8 +1,5 @@
 # Cmake toolchain description file for the Makefile
 
-# This is arbitrary, AFAIK, for now.
-cmake_minimum_required(VERSION 3.5.0)
-
 # Until Platform/WASI.cmake is upstream we need to inject the path to it
 # into CMAKE_MODULE_PATH.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")


### PR DESCRIPTION
This command is generally not included in toolchain files. It is used in
project configuration files that will consume the toolchain file. Also,
such a low value triggers warnings, support for <3.5.0 is being removed
from CMake.
