### PR TITLE
ci: troubleshoot mingw Git index

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,8 @@ jobs:
           # Upload the dist folder. Give it a name according to the OS it was built for.
           name: ${{ format( 'dist-windows-latest-{0}', matrix.arch) }}
           path: dist
+      - name: What does Git see as modified?
+        run: git diff --stat
 
   dockerbuild:
     name: Docker Build


### PR DESCRIPTION
For some unknown reason, the Windows build of wasi-sdk always creates artifacts that appear as if the current Git index is modified. This troubleshooting commit attempts to figure out why that is; do not merge.