### PR TITLE
Add python3 as build requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The Wasm-sdk's build process needs some packages :
 * `cmake`
 * `clang`
 * `ninja`
+* `python3`
 
 Please refer to your OS documentation to install those packages.
 


### PR DESCRIPTION
When trying to build the wasi-sdk I noticed that `python3` was not mentioned in the build process requirements. Since it is not part of the standard environment on most distributions I thought it would be a good idea to add it.
Cheers!