### PR TITLE
Update the version of `wasm-component-ld` used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ build/llvm.BUILT:
 # used for the `wasm32-wasip2` target natively by Clang. Note that `--root`
 # passed to `cargo install` will place it in the output directory automatically.
 build/wasm-component-ld.BUILT: build/llvm.BUILT
-	cargo install wasm-component-ld@0.1.5 --root $(BUILD_PREFIX)
+	cargo install wasm-component-ld@0.5.0 --root $(BUILD_PREFIX)
 	touch build/wasm-component-ld.BUILT
 
 


### PR DESCRIPTION
Recent changes have added various flags for customizing the component-creation process in addition to supporting more flags being forwarded to `wasm-ld`.