### PR TITLE
Add DWARF debugging information to all artifacts by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ WASI_LIBC_MAKEFLAGS = \
 	AR=$(BUILD_PREFIX)/bin/llvm-ar \
 	NM=$(BUILD_PREFIX)/bin/llvm-nm \
 	SYSROOT=$(BUILD_PREFIX)/share/wasi-sysroot \
+	EXTRA_CFLAGS="$(WASI_SDK_CFLAGS)" \
 	TARGET_TRIPLE=$(1)
 
 build/wasi-libc.BUILT: build/compiler-rt.BUILT build/wasm-component-ld.BUILT

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ CLANG_VERSION=$(shell $(VERSION_SCRIPT) llvm-major --llvm-dir=$(LLVM_PROJ_DIR))
 VERSION:=$(shell $(VERSION_SCRIPT))
 DEBUG_PREFIX_MAP=-fdebug-prefix-map=$(ROOT_DIR)=wasisdk://v$(VERSION)
 
+# Generate debuginfo by default for wasi-sdk since it's easily strippable and
+# otherwise quite useful for debugging.
+WASI_SDK_CFLAGS := $(DEBUG_PREFIX_MAP) -g
+WASI_SDK_CXXFLAGS := $(WASI_SDK_CFLAGS)
+
 default: build
 	@echo "Use -fdebug-prefix-map=$(ROOT_DIR)=wasisdk://v$(VERSION)"
 
@@ -166,7 +171,7 @@ build/compiler-rt.BUILT: build/llvm.BUILT
 		-DCOMPILER_RT_ENABLE_IOS=OFF \
 		-DCOMPILER_RT_DEFAULT_TARGET_ONLY=On \
 		-DWASI_SDK_PREFIX=$(BUILD_PREFIX) \
-		-DCMAKE_C_FLAGS="$(DEBUG_PREFIX_MAP)" \
+		-DCMAKE_C_FLAGS="$(WASI_SDK_CFLAGS)" \
 		-DLLVM_CONFIG_PATH=$(ROOT_DIR)/build/llvm/bin/llvm-config \
 		-DCOMPILER_RT_OS_DIR=wasi \
 		-DCMAKE_INSTALL_PREFIX=$(PREFIX)/lib/clang/$(CLANG_VERSION)/ \
@@ -225,8 +230,8 @@ LIBCXX_CMAKE_FLAGS = \
     -DUNIX:BOOL=ON \
     --debug-trycompile \
     -DCMAKE_SYSROOT=$(BUILD_PREFIX)/share/wasi-sysroot \
-    -DCMAKE_C_FLAGS="$(DEBUG_PREFIX_MAP) $(EXTRA_CFLAGS) $(4) --target=$(3)" \
-    -DCMAKE_CXX_FLAGS="$(DEBUG_PREFIX_MAP) $(EXTRA_CXXFLAGS) $(4) --target=$(3)" \
+    -DCMAKE_C_FLAGS="$(WASI_SDK_CFLAGS) $(EXTRA_CFLAGS) $(4) --target=$(3)" \
+    -DCMAKE_CXX_FLAGS="$(WASI_SDK_CXXFLAGS) $(EXTRA_CXXFLAGS) $(4) --target=$(3)" \
     -DLIBCXX_LIBDIR_SUFFIX=$(ESCAPE_SLASH)/$(3) \
     -DLIBCXXABI_LIBDIR_SUFFIX=$(ESCAPE_SLASH)/$(3) \
     -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \

--- a/tests/general/abort.c.stderr.expected
+++ b/tests/general/abort.c.stderr.expected
@@ -1,6 +1,7 @@
 Error: failed to run main module `abort.c.---.wasm`
 
 Caused by:
-    0: failed to invoke command default
+    0: failed to invoke ---
     1: error while executing at wasm backtrace:
+       note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information
     2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/abort.c.stderr.expected.filter
+++ b/tests/general/abort.c.stderr.expected.filter
@@ -3,4 +3,5 @@ set -euo pipefail
 
 cat \
     | sed -e 's/main module `abort\.c\.[^`]*\.wasm`/main module `abort.c.---.wasm`/' \
+    | sed -e 's/failed to invoke.*/failed to invoke ---/' \
     | sed -E '/0x[[:xdigit:]]+/d'

--- a/tests/general/abort.c.wasm32-wasi-preview2.stderr.expected
+++ b/tests/general/abort.c.wasm32-wasi-preview2.stderr.expected
@@ -1,6 +1,0 @@
-Error: failed to run main module `abort.c.---.wasm`
-
-Caused by:
-    0: failed to invoke `run` function
-    1: error while executing at wasm backtrace:
-    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/abort.c.wasm32-wasi.stderr.expected
+++ b/tests/general/abort.c.wasm32-wasi.stderr.expected
@@ -1,6 +1,0 @@
-Error: failed to run main module `abort.c.---.wasm`
-
-Caused by:
-    0: failed to invoke command default
-    1: error while executing at wasm backtrace:
-    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/abort.c.wasm32-wasip2.stderr.expected
+++ b/tests/general/abort.c.wasm32-wasip2.stderr.expected
@@ -1,6 +1,0 @@
-Error: failed to run main module `abort.c.---.wasm`
-
-Caused by:
-    0: failed to invoke `run` function
-    1: error while executing at wasm backtrace:
-    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/assert-fail.c.stderr.expected
+++ b/tests/general/assert-fail.c.stderr.expected
@@ -2,6 +2,7 @@ Assertion failed: false (assert-fail.c: main: 5)
 Error: failed to run main module `assert-fail.c.---.wasm`
 
 Caused by:
-    0: failed to invoke command default
+    0: failed to invoke ---
     1: error while executing at wasm backtrace:
+       note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information
     2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/assert-fail.c.stderr.expected.filter
+++ b/tests/general/assert-fail.c.stderr.expected.filter
@@ -3,4 +3,5 @@ set -euo pipefail
 
 cat \
     | sed -e 's/main module `assert-fail\.c\.[^`]*\.wasm`/main module `assert-fail.c.---.wasm`/' \
+    | sed -e 's/failed to invoke.*/failed to invoke ---/' \
     | sed -E '/0x[[:xdigit:]]+/d'

--- a/tests/general/assert-fail.c.wasm32-wasi-preview2.stderr.expected
+++ b/tests/general/assert-fail.c.wasm32-wasi-preview2.stderr.expected
@@ -1,7 +1,0 @@
-Assertion failed: false (assert-fail.c: main: 5)
-Error: failed to run main module `assert-fail.c.---.wasm`
-
-Caused by:
-    0: failed to invoke `run` function
-    1: error while executing at wasm backtrace:
-    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/assert-fail.c.wasm32-wasip2.stderr.expected
+++ b/tests/general/assert-fail.c.wasm32-wasip2.stderr.expected
@@ -1,7 +1,0 @@
-Assertion failed: false (assert-fail.c: main: 5)
-Error: failed to run main module `assert-fail.c.---.wasm`
-
-Caused by:
-    0: failed to invoke `run` function
-    1: error while executing at wasm backtrace:
-    2: wasm trap: wasm `unreachable` instruction executed

--- a/tests/general/stat.c
+++ b/tests/general/stat.c
@@ -43,10 +43,20 @@ int main(int argc, char *argv[]) {
 
     assert(file_statbuf.st_dev == link_statbuf.st_dev);
 
-    // Clear out the access time fields, and they should be the same.
-    memset(&file_statbuf.st_atim, 0, sizeof(struct timespec));
-    memset(&link_statbuf.st_atim, 0, sizeof(struct timespec));
-    assert(memcmp(&file_statbuf, &link_statbuf, sizeof(struct stat)) == 0);
+    assert(file_statbuf.st_dev == link_statbuf.st_dev);
+    assert(file_statbuf.st_ino == link_statbuf.st_ino);
+    assert(file_statbuf.st_mode == link_statbuf.st_mode);
+    assert(file_statbuf.st_uid == link_statbuf.st_uid);
+    assert(file_statbuf.st_gid == link_statbuf.st_gid);
+    assert(file_statbuf.st_rdev == link_statbuf.st_rdev);
+    assert(file_statbuf.st_size == link_statbuf.st_size);
+    assert(file_statbuf.st_blksize == link_statbuf.st_blksize);
+    assert(file_statbuf.st_blocks == link_statbuf.st_blocks);
+    // NB: `atim` is explicitly not compared here
+    assert(file_statbuf.st_mtim.tv_sec == link_statbuf.st_mtim.tv_sec);
+    assert(file_statbuf.st_mtim.tv_nsec == link_statbuf.st_mtim.tv_nsec);
+    assert(file_statbuf.st_ctim.tv_sec == link_statbuf.st_ctim.tv_sec);
+    assert(file_statbuf.st_ctim.tv_nsec == link_statbuf.st_ctim.tv_nsec);
 
     // Test lstat.
 


### PR DESCRIPTION
This commit adds DWARF debugging information with the `-g` compiler flag to all WASI artifacts for wasi-sdk. The LLVM build itself does not have debugging information, only the sysroot artifacts. This is intended to assist with debugging. The main downside to this is binary size of generated artifacts will, by default, be larger. Stripping debug information from an artifact though involves removing custom sections which is generally pretty easy to do through wasm tooling.