### PR TITLE
Pass `-O2 -DNDEBUG` to wasi-libc again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ WASI_LIBC_MAKEFLAGS = \
 	AR=$(BUILD_PREFIX)/bin/llvm-ar \
 	NM=$(BUILD_PREFIX)/bin/llvm-nm \
 	SYSROOT=$(BUILD_PREFIX)/share/wasi-sysroot \
-	EXTRA_CFLAGS="$(WASI_SDK_CFLAGS)" \
+	EXTRA_CFLAGS="$(WASI_SDK_CFLAGS) -O2 -DNDEBUG" \
 	TARGET_TRIPLE=$(1)
 
 build/wasi-libc.BUILT: build/compiler-rt.BUILT build/wasm-component-ld.BUILT


### PR DESCRIPTION
I forgot in #422 that by specifying `EXTRA_CFLAGS` to the wasi-libc build that it would override the defaults of wasi-libc which is to pass these two flags in. This passes them back in to ensure the default build still has the same flags.