### PR TITLE
Update wasm-component-ld to 0.5.4

### DIFF
--- a/cmake/wasi-sdk-toolchain.cmake
+++ b/cmake/wasi-sdk-toolchain.cmake
@@ -96,7 +96,7 @@ ExternalProject_Add(llvm-build
 # Build logic for `wasm-component-ld` installed from Rust code.
 set(wasm_component_ld_root ${CMAKE_CURRENT_BINARY_DIR}/wasm-component-ld)
 set(wasm_component_ld ${wasm_component_ld_root}/bin/wasm-component-ld${CMAKE_EXECUTABLE_SUFFIX})
-set(wasm_component_ld_version 0.5.0)
+set(wasm_component_ld_version 0.5.4)
 if(RUST_TARGET)
   set(rust_target_flag --target=${RUST_TARGET})
 endif()


### PR DESCRIPTION
This updates to the latest version of the linker which has better support for standard flags like `--version` and various other LLD flags.