### PR TITLE
Don't modify the host compiler's sysroot

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,8 +5,8 @@ include(CTest)
 enable_testing()
 set(CMAKE_EXECUTABLE_SUFFIX ".wasm")
 
-add_compile_options(--sysroot=${wasi_sysroot})
-add_link_options(--sysroot=${wasi_sysroot})
+add_compile_options(--sysroot=${wasi_sysroot} -resource-dir ${wasi_resource_dir})
+add_link_options(--sysroot=${wasi_sysroot} -resource-dir ${wasi_resource_dir})
 
 # Sanity check setup
 if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL WASI)


### PR DESCRIPTION
This commit updates the building of the wasi-sdk sysroot to leverage the `-resource-dir` argument from Clang to avoid modifying the host compiler's sysroot with compiler-rt things. This should help improve the experience of building a standalone sysroot with whatever host Clang is on the system.

Closes #444