### PR TITLE
update wasm-component-ld to 0.5.5

### DIFF
--- a/cmake/wasi-sdk-toolchain.cmake
+++ b/cmake/wasi-sdk-toolchain.cmake
@@ -119,7 +119,7 @@ install(DIRECTORY ${wasi_tmp_install}/bin ${wasi_tmp_install}/lib ${wasi_tmp_ins
 # Build logic for `wasm-component-ld` installed from Rust code.
 set(wasm_component_ld_root ${CMAKE_CURRENT_BINARY_DIR}/wasm-component-ld)
 set(wasm_component_ld ${wasm_component_ld_root}/bin/wasm-component-ld${CMAKE_EXECUTABLE_SUFFIX})
-set(wasm_component_ld_version 0.5.4)
+set(wasm_component_ld_version 0.5.5)
 if(RUST_TARGET)
   set(rust_target_flag --target=${RUST_TARGET})
 endif()


### PR DESCRIPTION
This includes support for a new `--component-type` option, which allows passing one or more component types as WIT files rather than (or in addition to) object files, which can be preferable when such files must be stored in source control.