### PR TITLE
Retire clang_version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,15 +25,10 @@ find_program(PYTHON python3 python REQUIRED)
 # Set some variables based on the `version.py` script
 set(version_script ${CMAKE_CURRENT_SOURCE_DIR}/version.py)
 execute_process(
-  COMMAND ${PYTHON} ${version_script} llvm-major --llvm-dir=${llvm_proj_dir}
-  OUTPUT_VARIABLE clang_version
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(
   COMMAND ${PYTHON} ${version_script}
   OUTPUT_VARIABLE wasi_sdk_version
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-message(STATUS "wasi-sdk toolchain LLVM version is ${clang_version}")
 message(STATUS "wasi-sdk version is ${wasi_sdk_version}")
 
 # Only include one version of the build logic as pulling in both isn't

--- a/cmake/wasi-sdk-sysroot.cmake
+++ b/cmake/wasi-sdk-sysroot.cmake
@@ -12,7 +12,7 @@ option(WASI_SDK_INCLUDE_TESTS "Whether or not to build tests by default" OFF)
 
 set(wasi_tmp_install ${CMAKE_CURRENT_BINARY_DIR}/install)
 set(wasi_sysroot ${wasi_tmp_install}/share/wasi-sysroot)
-set(wasi_resource_dir ${wasi_tmp_install}/lib/clang/${clang_version})
+set(wasi_resource_dir ${wasi_tmp_install}/wasi-resource-dir)
 
 # Force usage of the custom-built resource-dir and sysroot for the rest of the
 # wasi compiles.
@@ -243,9 +243,12 @@ endforeach()
 # misc build logic
 # =============================================================================
 
-install(DIRECTORY ${wasi_tmp_install}/lib ${wasi_tmp_install}/share
+install(DIRECTORY ${wasi_tmp_install}/share
         USE_SOURCE_PERMISSIONS
         DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(DIRECTORY ${wasi_resource_dir}/lib
+        USE_SOURCE_PERMISSIONS
+        DESTINATION ${clang_resource_dir})
 
 # Add a top-level `build` target as well as `build-$target` targets.
 add_custom_target(build ALL)
@@ -279,7 +282,7 @@ set(dist_dir ${CMAKE_CURRENT_BINARY_DIR}/dist)
 # Tarball with just `compiler-rt` builtins within it
 wasi_sdk_add_tarball(dist-compiler-rt
   ${dist_dir}/libclang_rt.builtins-wasm32-wasi-${wasi_sdk_version}.tar.gz
-  ${wasi_tmp_install}/lib/clang/${clang_version}/lib/wasi)
+  ${wasi_resource_dir}/lib/wasi)
 add_dependencies(dist-compiler-rt compiler-rt)
 
 # Tarball with the whole sysroot

--- a/cmake/wasi-sdk-sysroot.cmake
+++ b/cmake/wasi-sdk-sysroot.cmake
@@ -9,6 +9,7 @@ find_program(MAKE make REQUIRED)
 
 option(WASI_SDK_DEBUG_PREFIX_MAP "Pass `-fdebug-prefix-map` for built artifacts" ON)
 option(WASI_SDK_INCLUDE_TESTS "Whether or not to build tests by default" OFF)
+option(WASI_SDK_INSTALL_TO_CLANG_RESOURCE_DIR "Whether or not to modify the compiler's resource directory" OFF)
 
 set(wasi_tmp_install ${CMAKE_CURRENT_BINARY_DIR}/install)
 set(wasi_sysroot ${wasi_tmp_install}/share/wasi-sysroot)
@@ -246,13 +247,14 @@ endforeach()
 install(DIRECTORY ${wasi_tmp_install}/share
         USE_SOURCE_PERMISSIONS
         DESTINATION ${CMAKE_INSTALL_PREFIX})
-cmake_path(IS_PREFIX CMAKE_INSTALL_PREFIX ${clang_resource_dir} NORMALIZE install_resource_dir)
-if(install_resource_dir)
+if(WASI_SDK_INSTALL_TO_CLANG_RESOURCE_DIR)
   install(DIRECTORY ${wasi_resource_dir}/lib
           USE_SOURCE_PERMISSIONS
           DESTINATION ${clang_resource_dir})
 else()
-  message(STATUS "The resource dir (${clang_resource_dir}) will not be updated by the install target because it's out of CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}")
+  install(DIRECTORY ${wasi_resource_dir}/lib
+          USE_SOURCE_PERMISSIONS
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/clang-resource-dir)
 endif()
 
 # Add a top-level `build` target as well as `build-$target` targets.

--- a/cmake/wasi-sdk-sysroot.cmake
+++ b/cmake/wasi-sdk-sysroot.cmake
@@ -246,9 +246,14 @@ endforeach()
 install(DIRECTORY ${wasi_tmp_install}/share
         USE_SOURCE_PERMISSIONS
         DESTINATION ${CMAKE_INSTALL_PREFIX})
-install(DIRECTORY ${wasi_resource_dir}/lib
-        USE_SOURCE_PERMISSIONS
-        DESTINATION ${clang_resource_dir})
+cmake_path(IS_PREFIX CMAKE_INSTALL_PREFIX ${clang_resource_dir} NORMALIZE install_resource_dir)
+if(install_resource_dir)
+  install(DIRECTORY ${wasi_resource_dir}/lib
+          USE_SOURCE_PERMISSIONS
+          DESTINATION ${clang_resource_dir})
+else()
+  message(STATUS "The resource dir (${clang_resource_dir}) will not be updated by the install target because it's out of CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}")
+endif()
 
 # Add a top-level `build` target as well as `build-$target` targets.
 add_custom_target(build ALL)


### PR DESCRIPTION
Note: this makes the "install" target install the compiler rt into the compiler's runtime directory.  IMO, it's what "install" is supposed to do.  If you want to avoid modifing the runtime directory for some reasons, you can still do "dist" without "install".