### PR TITLE
Refactor handling env vars in CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,26 +24,50 @@ jobs:
           - artifact: arm64-linux
             os: ubuntu-latest
             rust_target: aarch64-unknown-linux-gnu
+            env:
+              # Don't build a sysroot for this cross-compiled target since it
+              # would require a host compiler and the sysroot is otherwise
+              # already built on other CI builders.
+              WASI_SDK_CI_SKIP_SYSROOT: 1
+
+              WASI_SDK_CI_TOOLCHAIN_LLVM_CMAKE_ARGS: >-
+                -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc
+                -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++
+                -DCMAKE_CROSSCOMPILING=True
+                -DCMAKE_CXX_FLAGS=-march=armv8-a
+                -DCMAKE_SYSTEM_PROCESSOR=arm64
+                -DCMAKE_SYSTEM_NAME=Linux
+                -DLLVM_HOST_TRIPLE=aarch64-linux-gnu
+                -DRUST_TARGET=aarch64-unknown-linux-gnu
 
           - artifact: arm64-macos
             os: macos-latest
-            llvm_cmake_flags: -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DCMAKE_OSX_ARCHITECTURES=arm64
             rust_target: aarch64-apple-darwin
+            env:
+              WASI_SDK_CI_TOOLCHAIN_LLVM_CMAKE_ARGS: >-
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
+                -DCMAKE_OSX_ARCHITECTURES=arm64
 
           - artifact: x86_64-macos
             os: macos-latest
-            llvm_cmake_flags: -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DCMAKE_OSX_ARCHITECTURES=x86_64
             rust_target: x86_64-apple-darwin
-            skip_sysroot: 1
+            env:
+              WASI_SDK_CI_SKIP_SYSROOT: 1
+              WASI_SDK_CI_TOOLCHAIN_LLVM_CMAKE_ARGS: >-
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
+                -DCMAKE_OSX_ARCHITECTURES=x86_64
 
           - artifact: x86_64-windows
             os: windows-latest
-            # TODO: tests are pretty close to passing on Windows but need some
-            # final tweaks, namely testing the exit code doesn't work since
-            # exit codes are different on Windows and the `mmap.c` tests seems
-            # to have issues probably with line endings. Needs someone with a
-            # Windows checkout tot test further.
-            skip_tests: 1
+            env:
+              # TODO: tests are pretty close to passing on Windows but need some
+              # final tweaks, namely testing the exit code doesn't work since
+              # exit codes are different on Windows and the `mmap.c` tests seems
+              # to have issues probably with line endings. Needs someone with a
+              # Windows checkout tot test further.
+              WASI_SDK_CI_SKIP_TESTS: 1
+
+    env: ${{ matrix.env || fromJSON('{}') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,9 +101,6 @@ jobs:
 
       # Configure CMake flags for `ci/build.sh` as necessary for each
       # matrix entry.
-      - run: echo WASI_SDK_CI_TOOLCHAIN_LLVM_CMAKE_ARGS=${{ matrix.llvm_cmake_flags }} >> $GITHUB_ENV
-        if: matrix.llvm_cmake_flags != ''
-        shell: bash
       - run: |
           cmake_args=-DWASI_SDK_ARTIFACT=${{ matrix.artifact }}
           if [ "${{ matrix.rust_target }}" != "" ]; then
@@ -88,12 +109,6 @@ jobs:
           fi
           echo WASI_SDK_CI_TOOLCHAIN_CMAKE_ARGS="$cmake_args" >> $GITHUB_ENV
         shell: bash
-      - run: echo WASI_SDK_CI_SKIP_SYSROOT=1 >> $GITHUB_ENV
-        shell: bash
-        if: matrix.skip_sysroot != ''
-      - run: echo WASI_SDK_CI_SKIP_TESTS=1 >> $GITHUB_ENV
-        shell: bash
-        if: matrix.skip_tests != ''
 
       # Add some extra installed software on each runner as necessary.
       - name: Setup `wasmtime` for tests

--- a/ci/docker-build.sh
+++ b/ci/docker-build.sh
@@ -48,6 +48,12 @@ args="$args --volume $ccache_dir:/ccache:Z --env CCACHE_DIR=/ccache"
 args="$args --volume `rustc --print sysroot`:/rustc:ro"
 args="$args --volume $(dirname $(which wasmtime)):/wasmtime:ro"
 
+# Pass through some env vars that `build.sh` reads
+args="$args --env WASI_SDK_CI_TOOLCHAIN_CMAKE_ARGS"
+args="$args --env WASI_SDK_CI_TOOLCHAIN_LLVM_CMAKE_ARGS"
+args="$args --env WASI_SDK_CI_SKIP_SYSROOT"
+args="$args --env WASI_SDK_CI_SKIP_TESTS"
+
 # Before running `ci/build.sh` set up some rust/PATH related info to use what
 # was just mounted above, and then execute the build.
 docker run \

--- a/ci/docker/Dockerfile.arm64-linux
+++ b/ci/docker/Dockerfile.arm64-linux
@@ -2,22 +2,4 @@ FROM wasi-sdk-builder-base
 
 RUN apt-get install -y g++-aarch64-linux-gnu
 
-# Don't build a sysroot for this cross-compiled target since it would require a
-# host compiler and the sysroot is otherwise already built on other CI builders.
-ENV WASI_SDK_CI_SKIP_SYSROOT 1
-
-ENV WASI_SDK_CI_TOOLCHAIN_LLVM_CMAKE_ARGS \
-  -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
-  -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
-  -DCMAKE_CROSSCOMPILING=True \
-  -DCMAKE_CXX_FLAGS=-march=armv8-a \
-  -DCMAKE_SYSTEM_PROCESSOR=arm64 \
-  -DCMAKE_SYSTEM_NAME=Linux \
-  -DLLVM_HOST_TRIPLE=aarch64-linux-gnu \
-  -DRUST_TARGET=aarch64-unknown-linux-gnu
-
-ENV WASI_SDK_CI_TOOLCHAIN_CMAKE_ARGS \
-  -DWASI_SDK_ARTIFACT=arm64-linux \
-  -DRUST_TARGET=aarch64-unknown-linux-gnu
-
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER aarch64-linux-gnu-gcc

--- a/ci/docker/Dockerfile.arm64-linux
+++ b/ci/docker/Dockerfile.arm64-linux
@@ -1,5 +1,11 @@
 FROM wasi-sdk-builder-base
 
+# Install an extra C++ toolchain which can target arm64 linux.
 RUN apt-get install -y g++-aarch64-linux-gnu
 
+# Configure Rust to use this new compiler for linking Rust executables.
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER aarch64-linux-gnu-gcc
+
+# Note that `.github/workflows/main.yml` sets various bits and bobs of
+# configuration and cmake flags that may get passed to the underlying build. For
+# example LLVM is instructed to use the toolchain installed above.

--- a/ci/docker/Dockerfile.common
+++ b/ci/docker/Dockerfile.common
@@ -4,6 +4,7 @@
 
 FROM ubuntu:18.04
 
+# Various build tooling and such necessary to build LLVM and a wasi-sysroot
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
   ccache \
@@ -16,6 +17,8 @@ RUN apt-get update \
   unzip \
   xz-utils
 
+# Install a more recent version of CMake than what 18.04 has since that's what
+# LLVM requires.
 RUN curl -sSLO https://github.com/Kitware/CMake/releases/download/v3.29.5/cmake-3.29.5-linux-x86_64.tar.gz \
   && tar xf cmake-3.29.5-linux-x86_64.tar.gz \
   && rm cmake-3.29.5-linux-x86_64.tar.gz \
@@ -24,9 +27,12 @@ RUN curl -sSLO https://github.com/Kitware/CMake/releases/download/v3.29.5/cmake-
 
 ENV PATH /opt/cmake/bin:$PATH
 
+# As with CMake install a later version of Ninja than waht 18.04 has.
 RUN curl -sSLO https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip \
   && unzip ninja-linux.zip \
   && rm *.zip \
   && mv ninja /opt/cmake/bin
 
+# Tell programs to cache in a location that both isn't a `--volume` mounted root
+# and isn't `/root` in the container as that won't be writable during the build.
 ENV XDG_CACHE_HOME /tmp/cache

--- a/ci/docker/Dockerfile.x86_64-linux
+++ b/ci/docker/Dockerfile.x86_64-linux
@@ -1,1 +1,7 @@
 FROM wasi-sdk-builder-base
+
+# No extra configuration necessary for x86_64 over what `Dockerfile.common`
+# already has.
+#
+# Note though that `.github/workflows/main.yml` still sets various bits and bobs
+# of configuration and cmake flags that may get passed to the underlying build.

--- a/ci/docker/Dockerfile.x86_64-linux
+++ b/ci/docker/Dockerfile.x86_64-linux
@@ -1,4 +1,1 @@
 FROM wasi-sdk-builder-base
-
-ENV WASI_SDK_CI_TOOLCHAIN_CMAKE_ARGS \
-  -DWASI_SDK_ARTIFACT=x86_64-linux


### PR DESCRIPTION
This commit updates the handling of various environment variables to centralize them in one location in `main.yml` as part of CI configuration. This removes a few custom-named variables in favor of using explicitly-listed env vars. Additionally this moves some env var management from the CI container files to the github actions config as well to keep everything in one place ideally.