### PR TITLE
Use MSVC for the Windows toolchain instead of MinGW

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,6 +110,9 @@ jobs:
           echo WASI_SDK_CI_TOOLCHAIN_CMAKE_ARGS="$cmake_args" >> $GITHUB_ENV
         shell: bash
 
+      - name: Clear ccache statistics
+        run: ccache --zero-stats
+
       # Add some extra installed software on each runner as necessary.
       - name: Setup `wasmtime` for tests
         uses: bytecodealliance/actions/wasmtime/setup@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
       # MSVC to compile LLVM as that avoids extra runtime dependencies
       # msys/mingw might bring.
       #
-      # As of 2024-07-22 this sha is the "v1" tag.
+      # As of 2024-07-22 this sha is the "v1.13.0" tag.
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
         if: runner.os == 'Windows'
       - name: Build and test (Windows)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,9 +110,6 @@ jobs:
           echo WASI_SDK_CI_TOOLCHAIN_CMAKE_ARGS="$cmake_args" >> $GITHUB_ENV
         shell: bash
 
-      - name: Clear ccache statistics
-        run: ccache --zero-stats
-
       # Add some extra installed software on each runner as necessary.
       - name: Setup `wasmtime` for tests
         uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -127,6 +124,9 @@ jobs:
       - name: Install ccache, ninja (Linux)
         run: sudo apt install ccache
         if: runner.os == 'Linux'
+
+      - name: Clear ccache statistics
+        run: ccache --zero-stats
 
       - name: Build and test (macOS)
         run: ./ci/build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,11 +133,23 @@ jobs:
         run: ./ci/docker-build.sh ${{ matrix.artifact }}
         if: runner.os == 'Linux'
 
-      # Use a shorter build directory than the default on Windows to avoid
-      # hitting path length and command line length limits. See
-      # WebAssembly/wasi-libc#514
+      # Setup the VS Developoer Prompt environment variables to explicitly use
+      # MSVC to compile LLVM as that avoids extra runtime dependencies
+      # msys/mingw might bring.
+      #
+      # As of 2024-07-22 this sha is the "v1" tag.
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+        if: runner.os == 'Windows'
       - name: Build and test (Windows)
         run: |
+          # Delete a troublesome binary as recommended here
+          # https://github.com/ilammy/msvc-dev-cmd?tab=readme-ov-file#name-conflicts-with-shell-bash
+          rm /usr/bin/link
+          # Use a shorter build directory than the default on Windows to avoid
+          # hitting path length and command line length limits. See
+          # WebAssembly/wasi-libc#514. Despite using a different build directory
+          # though still move the `dist` folder to `build/dist` so the upload
+          # step below doesn't need a windows-specific hook.
           ./ci/build.sh C:/wasi-sdk
           mkdir build
           cp -r C:/wasi-sdk/dist build

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -18,6 +18,7 @@ fi
 
 cmake -G Ninja -B $build_dir/toolchain -S . \
   -DWASI_SDK_BUILD_TOOLCHAIN=ON \
+  -DCMAKE_BUILD_TYPE=MinSizeRel \
   "-DCMAKE_INSTALL_PREFIX=$build_dir/install" \
   $WASI_SDK_CI_TOOLCHAIN_CMAKE_ARGS \
   "-DLLVM_CMAKE_FLAGS=$WASI_SDK_CI_TOOLCHAIN_LLVM_CMAKE_ARGS"


### PR DESCRIPTION
Explicitly use MSVC to avoid the runtime dependencies that the default toolchain CMake is using is bringing in.

Closes #454