### PR TITLE
Prune ccache caches in CI on each run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,6 +137,15 @@ jobs:
           name: ${{ format( 'dist-{0}', matrix.artifact) }}
           path: build/dist
 
+      # Caches are persisted across runs by restoring the latest cache which
+      # means that quite a lot of cruft can accumulate. Prune older entries that
+      # haven't been used by this run to avoid the cache continuously getting
+      # larger. In theory this should use `--evict-older-than $dur` where `$dur`
+      # is the time since the start of the run, but I'm not sure how to easily
+      # calculate that so pick something loose like one day instead.
+      - name: Prune ccache objects
+        run: ccache --evict-older-than 1d
+
       # Help debug ccache issues by showing what happened.
       - if: always()
         name: Show ccache statistics


### PR DESCRIPTION
I noticed in a [recent build] that the cache size for Windows is quite large at 500M. That might be related to switching to MSVC, I'm not sure, but something else I've realized is that as-configured wasi-sdk will continuously grow the cache over time and it won't ever get trimmed until we hit github actions limits. This is because the cache is restored from an older version, then appended to with the current build, then saved again. That theoretically means that each builder could make up to a 5G cache which is a bit too large.

This commit adds an extra step that removes all objects older than 1d to ensure that older builds eventually get cleaned out of the cache. GitHub Actions should then still delete older caches pretty regularly but each individual cache should be bounded still.

[recent build]: https://github.com/WebAssembly/wasi-sdk/actions/runs/10045872592/job/27764084758?pr=456