### PR TITLE
Add `wasi-sdk-p1.cmake`

### DIFF
--- a/wasi-sdk-p1.cmake
+++ b/wasi-sdk-p1.cmake
@@ -1,0 +1,38 @@
+# Cmake toolchain description file for the Makefile
+
+# Until Platform/WASI.cmake is upstream we need to inject the path to it
+# into CMAKE_MODULE_PATH.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+set(CMAKE_SYSTEM_NAME WASI)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR wasm32)
+set(triple wasm32-wasip1)
+
+if(WIN32)
+	set(WASI_HOST_EXE_SUFFIX ".exe")
+else()
+	set(WASI_HOST_EXE_SUFFIX "")
+endif()
+
+# When building from source, WASI_SDK_PREFIX represents the generated directory
+if(NOT WASI_SDK_PREFIX)
+	set(WASI_SDK_PREFIX ${CMAKE_CURRENT_LIST_DIR}/../../)
+endif()
+
+set(CMAKE_C_COMPILER ${WASI_SDK_PREFIX}/bin/clang${WASI_HOST_EXE_SUFFIX})
+set(CMAKE_CXX_COMPILER ${WASI_SDK_PREFIX}/bin/clang++${WASI_HOST_EXE_SUFFIX})
+set(CMAKE_ASM_COMPILER ${WASI_SDK_PREFIX}/bin/clang${WASI_HOST_EXE_SUFFIX})
+set(CMAKE_AR ${WASI_SDK_PREFIX}/bin/llvm-ar${WASI_HOST_EXE_SUFFIX})
+set(CMAKE_RANLIB ${WASI_SDK_PREFIX}/bin/llvm-ranlib${WASI_HOST_EXE_SUFFIX})
+set(CMAKE_C_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_ASM_COMPILER_TARGET ${triple})
+
+# Don't look in the sysroot for executables to run during the build
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# Only look in the sysroot (not in the host paths) for the rest
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)


### PR DESCRIPTION
Like we have for other targets, this adds a `.cmake` file for the new name of the old `wasm32-wasi` target, now called `wasm32-wasip1` in `wasi-libc`.