### PR TITLE
Fix testing the right targets on CI

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -47,4 +47,5 @@ if [ "$WASI_SDK_CI_SKIP_TESTS" = "1" ]; then
 fi
 
 # Run tests to ensure that the sysroot works.
-ctest --output-on-failure --parallel 10 --test-dir $build_dir/sysroot/tests
+ctest --output-on-failure --parallel 10 --test-dir $build_dir/sysroot/tests \
+  --timeout 60

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ function(add_testcase runwasi test)
       # as well.
       if(NOT(CMAKE_C_COMPILER MATCHES ${target}))
         target_compile_options(${target_name} PRIVATE --target=${target})
+        target_link_options(${target_name} PRIVATE --target=${target})
       endif()
 
       # Apply test-specific compile options and link flags.
@@ -79,6 +80,7 @@ function(add_testcase runwasi test)
       # Apply target-specific options.
       if(target MATCHES threads)
         target_compile_options(${target_name} PRIVATE -pthread)
+        target_link_options(${target_name} PRIVATE -pthread)
       endif()
 
       if(runwasi)

--- a/tests/general/sigabrt.c.stderr.expected
+++ b/tests/general/sigabrt.c.stderr.expected
@@ -3,4 +3,4 @@ Program received fatal signal: Aborted
 Error: failed to run main module `sigabrt.c.---.wasm`
 
 Caused by:
-    0: failed to invoke command default
+    0: failed to invoke ---

--- a/tests/general/sigabrt.c.stderr.expected.filter
+++ b/tests/general/sigabrt.c.stderr.expected.filter
@@ -4,4 +4,5 @@ set -euo pipefail
 cat \
     | sed -e 's/main module `.*sigabrt\.c\.wasm`/main module `sigabrt.c.---.wasm`/' \
     | sed -e 's/source location: @[[:xdigit:]]*$/source location: @----/' \
+    | sed -e 's/failed to invoke.*/failed to invoke ---/' \
     | head -n 6


### PR DESCRIPTION
This commit fixes a bug from the cmake migration where tests were not actually testing the correct target. Object files were compiled with the right options but the link step was missing both `--target` and `-pthread` which caused everything to accidentally be tested as `wasm32-wasi`. When fixing this one test was needed to have its stderr updated because the component output of `wasm32-wasip2` is slightly different. A timeout was additionally added because without `-pthread` at the link step some tests infinitely ran which made debugging difficult.