### PR TITLE
Disable docker cache with github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,8 +242,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Publish a draft release
         if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
The container in this repository does not take long to build and the caches look like they're take a nontrivial amount of space in CI. Try to free up more room for LLVM caches which are the main reason to use caching in this repository.