### PR TITLE
Clone a larger depth in submodules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
       # bump depth (or even better, the submodule), in case of "error:
       # Server does not allow request for unadvertised object" in the
       # future.
-      - run: git submodule update --init --depth 32 --jobs 3
+      - run: git submodule update --init --depth 64 --jobs 3
 
       # Persist ccache-based caches across builds. This directory is configured
       # via the CCACHE_DIR env var below for ccache to use.
@@ -265,7 +265,7 @@ jobs:
           fetch-depth: 0
       - run: git fetch --tags --force
         name: Force-fetch tags to work around actions/checkout#290
-      - run: git submodule update --init --depth 32 --jobs 3
+      - run: git submodule update --init --depth 64 --jobs 3
       - name: Setup `wasmtime` for tests
         uses: bytecodealliance/actions/wasmtime/setup@v1
         with:


### PR DESCRIPTION
This is an attempt to fix CI errors where the `config` submodule is now located on a commit further than 32 commits behind the main branch (presumably).