### PR TITLE
Add a test on CI that just the sysroot can be built

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,0 +1,16 @@
+name: 'Prepare wasi-sdk git directory'
+description: 'Prepare wasi-sdk git directory'
+
+runs:
+  using: composite
+  steps:
+    - run: git fetch --tags --force
+      name: Force-fetch tags to work around actions/checkout#290
+      shell: bash
+    # We can't use `--depth 1` here sadly because the GNU config
+    # submodule is not pinned to a particular tag/branch. Please
+    # bump depth (or even better, the submodule), in case of "error:
+    # Server does not allow request for unadvertised object" in the
+    # future.
+    - run: git submodule update --init --depth 64 --jobs 3
+      shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,0 +1,22 @@
+name: 'Install wasi-sdk dependencies'
+description: 'Install wasi-sdk dependencies'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup `wasmtime` for tests
+      uses: bytecodealliance/actions/wasmtime/setup@v1
+      with:
+        version: "18.0.2"
+    - name: Install ccache, ninja (macOS)
+      run: brew install ccache ninja
+      if: runner.os == 'macOS'
+      shell: bash
+    - name: Install ccache, ninja (Windows)
+      run: choco install ccache ninja
+      if: runner.os == 'Windows'
+      shell: bash
+    - name: Install ccache, ninja (Linux)
+      run: sudo apt-get install -y ccache ninja-build
+      if: runner.os == 'Linux'
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,14 +72,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: git fetch --tags --force
-        name: Force-fetch tags to work around actions/checkout#290
-      # We can't use `--depth 1` here sadly because the GNU config
-      # submodule is not pinned to a particular tag/branch. Please
-      # bump depth (or even better, the submodule), in case of "error:
-      # Server does not allow request for unadvertised object" in the
-      # future.
-      - run: git submodule update --init --depth 64 --jobs 3
+      - uses: ./.github/actions/checkout
+      - uses: ./.github/actions/install-deps
 
       # Persist ccache-based caches across builds. This directory is configured
       # via the CCACHE_DIR env var below for ccache to use.
@@ -109,21 +103,6 @@ jobs:
           fi
           echo WASI_SDK_CI_TOOLCHAIN_CMAKE_ARGS="$cmake_args" >> $GITHUB_ENV
         shell: bash
-
-      # Add some extra installed software on each runner as necessary.
-      - name: Setup `wasmtime` for tests
-        uses: bytecodealliance/actions/wasmtime/setup@v1
-        with:
-          version: "18.0.2"
-      - name: Install ccache, ninja (macOS)
-        run: brew install ccache ninja
-        if: runner.os == 'macOS'
-      - name: Install ccache, ninja (Windows)
-        run: choco install ccache ninja
-        if: runner.os == 'Windows'
-      - name: Install ccache, ninja (Linux)
-        run: sudo apt install ccache
-        if: runner.os == 'Linux'
 
       - name: Clear ccache statistics
         run: ccache --zero-stats
@@ -191,6 +170,30 @@ jobs:
           path: ${{ runner.tool_cache }}/ccache
           key: 0-cache-${{ matrix.artifact }}-${{ github.run_id }}
 
+  build-only-sysroot:
+    name: Build only sysroot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/checkout
+      - uses: ./.github/actions/install-deps
+      - run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          name=$(lsb_release -s -c)
+          sudo add-apt-repository -y "deb http://apt.llvm.org/$name/ llvm-toolchain-$name-18 main"
+          sudo add-apt-repository -y "deb-src http://apt.llvm.org/$name/ llvm-toolchain-$name-18 main"
+          sudo apt-get install -y clang-18 llvm-18 lld-18
+      - run: cargo install wasm-component-ld@0.5.5
+      - run: |
+          cmake -G Ninja -B build -S . \
+            -DCMAKE_C_COMPILER=/usr/lib/llvm-18/bin/clang \
+            -DCMAKE_SYSTEM_NAME=WASI \
+            -DWASI_SDK_INCLUDE_TESTS=ON
+      - run: ninja -C build
+      - run: ctest --output-on-failure --parallel 10 --test-dir build/tests
+
   # Once all of the above matrix entries have completed this job will run and
   # assemble the final `wasi-sdk-*` artifacts by fusing the toolchain/sysroot
   # artifacts.
@@ -202,8 +205,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: git fetch --tags --force
-        name: Force-fetch tags to work around actions/checkout#290
+      - uses: ./.github/actions/checkout
 
       # Download all artifacts from all platforms in `build`, merge them into
       # final wasi-sdk-* artifacts, and then upload them.
@@ -263,16 +265,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: git fetch --tags --force
-        name: Force-fetch tags to work around actions/checkout#290
-      - run: git submodule update --init --depth 64 --jobs 3
-      - name: Setup `wasmtime` for tests
-        uses: bytecodealliance/actions/wasmtime/setup@v1
-        with:
-          version: "18.0.2"
-      - name: Install ninja
-        run: sudo apt-get install -y ninja-build
-        if: runner.os == 'Linux'
+      - uses: ./.github/actions/checkout
+      - uses: ./.github/actions/install-deps
       - uses: actions/download-artifact@v4
         with:
           name: dist-x86_64-linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@
 # the host.
 
 cmake_minimum_required(VERSION 3.26)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 project(wasi-sdk)
 include(ExternalProject)
 
@@ -17,7 +18,6 @@ option(WASI_SDK_BUILD_TOOLCHAIN "Build a toolchain instead of the sysroot" OFF)
 set(llvm_proj_dir ${CMAKE_CURRENT_SOURCE_DIR}/src/llvm-project)
 set(wasi_libc ${CMAKE_CURRENT_SOURCE_DIR}/src/wasi-libc)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(wasi-sdk-enable-ccache)
 
 find_program(PYTHON python3 python REQUIRED)

--- a/cmake/wasi-sdk-sysroot.cmake
+++ b/cmake/wasi-sdk-sysroot.cmake
@@ -15,6 +15,9 @@ if(CMAKE_C_COMPILER_VERSION VERSION_LESS ${minimum_clang_required})
   message(FATAL_ERROR "compiler version ${CMAKE_C_COMPILER_VERSION} is less than the required version ${minimum_clang_required}")
 endif()
 
+message(STATUS "Found executable for `nm`: ${CMAKE_NM}")
+message(STATUS "Found executable for `ar`: ${CMAKE_AR}")
+
 find_program(MAKE make REQUIRED)
 
 option(WASI_SDK_DEBUG_PREFIX_MAP "Pass `-fdebug-prefix-map` for built artifacts" ON)
@@ -133,6 +136,7 @@ function(define_wasi_libc_sub target target_suffix lto)
 
   string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPER)
   get_property(directory_cflags DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY COMPILE_OPTIONS)
+  list(APPEND directory_cflags -resource-dir ${wasi_resource_dir})
   set(extra_cflags_list
     "${CMAKE_C_FLAGS} ${directory_cflags} ${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}")
   list(JOIN extra_cflags_list " " extra_cflags)


### PR DESCRIPTION
This commit adds a test and matrix entry to CI which asserts that the sysroot can be built to run tests using a stock Clang compiler found on the system. This fixes a few minor issues as well in developing this.

This additionally refactors CI a bit to move shared steps amongst jobs into separate composite actions in this repository to avoid duplication across jobs.