### PR TITLE
Run wasm tests on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,13 +59,6 @@ jobs:
 
           - artifact: x86_64-windows
             os: windows-latest
-            env:
-              # TODO: tests are pretty close to passing on Windows but need some
-              # final tweaks, namely testing the exit code doesn't work since
-              # exit codes are different on Windows and the `mmap.c` tests seems
-              # to have issues probably with line endings. Needs someone with a
-              # Windows checkout tot test further.
-              WASI_SDK_CI_SKIP_TESTS: 1
 
     env: ${{ matrix.env || fromJSON('{}') }}
     steps:

--- a/tests/general/mmap.c.dir/.gitattributes
+++ b/tests/general/mmap.c.dir/.gitattributes
@@ -1,0 +1,3 @@
+# This input is read at runtime during testing so ensure that the same input is
+# read on unix and windows by forcing just-a-newline for line endings.
+*.txt text eol=lf

--- a/tests/testcase.sh
+++ b/tests/testcase.sh
@@ -53,6 +53,14 @@ exit_status=0
     || exit_status=$?
 echo $exit_status > "$exit_status_observed"
 
+# On Windows Wasmtime will exit with error code 3 for aborts. On Unix Wasmtime
+# will exit with status 134. Paper over this difference by pretending to be Unix
+# on Windows and converting exit code 3 into 134 for the purposes of asserting
+# test output.
+if [ "$OSTYPE" = "msys" ] && [ "$exit_status" = "3" ]; then
+  echo 134 > "$exit_status_observed"
+fi
+
 # Determine the reference files to compare with.
 if [ -e "$input.stdout.expected" ]; then
   stdout_expected="$input.stdout.expected"


### PR DESCRIPTION
This commit fixes running the test suite on Windows for CI at least by fixing up a few minor edge cases to ensure that everything runs consistently.