### PR TITLE
Update wasm-component-ld to 0.5.6

### DIFF
--- a/cmake/wasi-sdk-toolchain.cmake
+++ b/cmake/wasi-sdk-toolchain.cmake
@@ -119,7 +119,7 @@ install(DIRECTORY ${wasi_tmp_install}/bin ${wasi_tmp_install}/lib ${wasi_tmp_ins
 # Build logic for `wasm-component-ld` installed from Rust code.
 set(wasm_component_ld_root ${CMAKE_CURRENT_BINARY_DIR}/wasm-component-ld)
 set(wasm_component_ld ${wasm_component_ld_root}/bin/wasm-component-ld${CMAKE_EXECUTABLE_SUFFIX})
-set(wasm_component_ld_version 0.5.5)
+set(wasm_component_ld_version 0.5.6)
 if(RUST_TARGET)
   set(rust_target_flag --target=${RUST_TARGET})
 endif()


### PR DESCRIPTION
This pulls in an update to how WIT files are processed notably around nested package forms in the text format.