### PR TITLE
Add `wasi-sdk-p1.cmake` to the artifacts

### DIFF
--- a/cmake/wasi-sdk-toolchain.cmake
+++ b/cmake/wasi-sdk-toolchain.cmake
@@ -154,6 +154,7 @@ copy_misc_file(src/config/config.sub misc)
 copy_misc_file(src/config/config.guess misc)
 copy_misc_file(wasi-sdk.cmake cmake)
 copy_misc_file(wasi-sdk-pthread.cmake cmake)
+copy_misc_file(wasi-sdk-p1.cmake cmake)
 copy_misc_file(wasi-sdk-p2.cmake cmake)
 copy_misc_file(cmake/Platform/WASI.cmake cmake/Platform)
 


### PR DESCRIPTION
It appears this was not done in https://github.com/WebAssembly/wasi-sdk/pull/459 and so the file is missing from the distribution.