### PR TITLE
Add back `VERSION` file to release tarballs

### DIFF
--- a/ci/merge-artifacts.sh
+++ b/ci/merge-artifacts.sh
@@ -60,6 +60,7 @@ for build in dist-*; do
   tar xf $toolchain -C dist/$sdk_dir --strip-components 1
   mkdir -p dist/$sdk_dir/share/wasi-sysroot
   tar xf $sysroot -C dist/$sdk_dir/share/wasi-sysroot --strip-components 1
+  mv dist/$sdk_dir/share/wasi-sysroot/VERSION dist/$sdk_dir
 
   # Setup the compiler-rt library for wasi,wasip1,wasip2
   rtlibdir=$(dirname $(find dist/$sdk_dir/lib -name include))/lib

--- a/cmake/wasi-sdk-sysroot.cmake
+++ b/cmake/wasi-sdk-sysroot.cmake
@@ -334,7 +334,7 @@ file(GENERATE OUTPUT ${version_file_tmp} CONTENT ${version_dump})
 add_custom_target(version-file DEPENDS ${version_file_tmp})
 add_dependencies(build version-file)
 install(FILES ${version_file_tmp}
-        DESTINATION ${CMAKE_INSTALL_PREFIX})
+        DESTINATION ${wasi_sysroot})
 
 if(WASI_SDK_INCLUDE_TESTS)
   add_subdirectory(tests)
@@ -353,7 +353,7 @@ add_dependencies(dist-compiler-rt compiler-rt)
 # Tarball with the whole sysroot
 wasi_sdk_add_tarball(dist-sysroot
   ${dist_dir}/wasi-sysroot-${wasi_sdk_version}.tar.gz
-  ${wasi_tmp_install}/share/wasi-sysroot)
+  ${wasi_sysroot})
 add_dependencies(dist-sysroot build)
 
 add_custom_target(dist DEPENDS dist-compiler-rt dist-sysroot)

--- a/cmake/wasi-sdk-sysroot.cmake
+++ b/cmake/wasi-sdk-sysroot.cmake
@@ -329,12 +329,10 @@ execute_process(
   COMMAND ${PYTHON} ${version_script} dump
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   OUTPUT_VARIABLE version_dump)
-set(version_file_tmp ${CMAKE_CURRENT_BINARY_DIR}/VERSION)
+set(version_file_tmp ${wasi_sysroot}/VERSION)
 file(GENERATE OUTPUT ${version_file_tmp} CONTENT ${version_dump})
 add_custom_target(version-file DEPENDS ${version_file_tmp})
 add_dependencies(build version-file)
-install(FILES ${version_file_tmp}
-        DESTINATION ${wasi_sysroot})
 
 if(WASI_SDK_INCLUDE_TESTS)
   add_subdirectory(tests)


### PR DESCRIPTION
Make sure it makes its way into the sysroot tarball and then copy it from the sysroot location to the top of the sdk tarball as well.

Closes #471