### PR TITLE
Add llvm-dwp binary to toolchain

### DIFF
--- a/cmake/wasi-sdk-toolchain.cmake
+++ b/cmake/wasi-sdk-toolchain.cmake
@@ -45,6 +45,7 @@ set(tools
   llvm-ranlib
   llvm-strip
   llvm-dwarfdump
+  llvm-dwp
   clang-resource-headers
   ar
   ranlib


### PR DESCRIPTION
There is an option to compile debug information to separate file. It's supported in Clang via -gsplit-dwarf to generate dwo files but we need llvm-dwp tool to combine them into single dwp file supported by Chrome DWARF extension https://developer.chrome.com/blog/faster-wasm-debugging

It is already supported in Emscripten https://github.com/emscripten-core/emscripten/issues/13251
