### PR TITLE
Fix installation and usage instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ tar xvf wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux.tar.gz
 Use the clang installed in the `wasi-sdk` directory:
 
 ```shell script
-export WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_VERSION_FULL}-{WASI_ARCH}-linux
+export WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux
 CC="${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot"
 $CC foo.c -o foo.wasm
 ```

--- a/README.md
+++ b/README.md
@@ -132,11 +132,12 @@ see [RELEASING.md](RELEASING.md).
 A typical installation from the release binaries might look like the following:
 
 ```shell script
+WASI_OS=linux
 WASI_ARCH=x86_64
 WASI_VERSION=24
 WASI_VERSION_FULL=${WASI_VERSION}.0
-wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux.tar.gz
-tar xvf wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux.tar.gz
+wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz
+tar xvf wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz
 ```
 
 ## Use
@@ -144,7 +145,7 @@ tar xvf wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux.tar.gz
 Use the clang installed in the `wasi-sdk` directory:
 
 ```shell script
-export WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux
+WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}
 CC="${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot"
 $CC foo.c -o foo.wasm
 ```

--- a/README.md
+++ b/README.md
@@ -132,10 +132,11 @@ see [RELEASING.md](RELEASING.md).
 A typical installation from the release binaries might look like the following:
 
 ```shell script
-export WASI_VERSION=20
+export WASI_ARCH=x86_64
+export WASI_VERSION=24
 export WASI_VERSION_FULL=${WASI_VERSION}.0
-wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
-tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
+wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux.tar.gz
+tar xvf wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux.tar.gz
 ```
 
 ## Use
@@ -143,7 +144,7 @@ tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
 Use the clang installed in the `wasi-sdk` directory:
 
 ```shell script
-export WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_VERSION_FULL}
+export WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_VERSION_FULL}-{WASI_ARCH}-linux
 CC="${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot"
 $CC foo.c -o foo.wasm
 ```

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ see [RELEASING.md](RELEASING.md).
 A typical installation from the release binaries might look like the following:
 
 ```shell script
-export WASI_ARCH=x86_64
-export WASI_VERSION=24
-export WASI_VERSION_FULL=${WASI_VERSION}.0
+WASI_ARCH=x86_64
+WASI_VERSION=24
+WASI_VERSION_FULL=${WASI_VERSION}.0
 wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux.tar.gz
 tar xvf wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-linux.tar.gz
 ```


### PR DESCRIPTION
Hi!

I just tried the installation scripts for the GitHub workflow and it seems like the release artifacts layout has been changed a bit, so installation and usage shell scripts need a little update.