### PR TITLE
Replace `DEFAULT_SYSROOT` usage with Clang config files

### DIFF
--- a/clang.cfg
+++ b/clang.cfg
@@ -1,0 +1,1 @@
+--sysroot=<CFGDIR>/../share/wasi-sysroot

--- a/cmake/wasi-sdk-toolchain.cmake
+++ b/cmake/wasi-sdk-toolchain.cmake
@@ -90,7 +90,6 @@ ExternalProject_Add(llvm-build
     -DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-wasi
     -DLLVM_INSTALL_BINUTILS_SYMLINKS=TRUE
     -DLLVM_ENABLE_LIBXML2=OFF
-    -DDEFAULT_SYSROOT=../share/wasi-sysroot
     # Pass `-s` to strip symbols by default and shrink the size of the
     # distribution
     -DCMAKE_EXE_LINKER_FLAGS=-s
@@ -158,6 +157,18 @@ copy_misc_file(wasi-sdk-pthread.cmake cmake)
 copy_misc_file(wasi-sdk-p1.cmake cmake)
 copy_misc_file(wasi-sdk-p2.cmake cmake)
 copy_misc_file(cmake/Platform/WASI.cmake cmake/Platform)
+
+function(copy_cfg_file compiler)
+  set(dst ${wasi_tmp_install}/bin/${compiler}.cfg)
+  add_custom_command(
+    OUTPUT ${dst}
+    COMMAND cmake -E copy ${CMAKE_CURRENT_SOURCE_DIR}/clang.cfg ${dst})
+  add_custom_target(copy-${compiler} DEPENDS ${dst})
+  add_dependencies(misc-files copy-${compiler})
+endfunction()
+
+copy_cfg_file(clang)
+copy_cfg_file(clang++)
 
 include(wasi-sdk-dist)
 


### PR DESCRIPTION
Upstream want to deprecate `DEFAULT_SYSROOT`[^1][^2][^3], but one
blocker is wasi-sdk's usage of it.

Let's try to help that along by switching to using config files[^4]
instead.

This should result in no user-facing changes in functionality. (If it
does, then that's an LLVM bug that should be fixed there.)

[^1]: https://reviews.llvm.org/D158218
[^2]: https://github.com/llvm/llvm-project/issues/94284
[^3]: https://github.com/llvm/llvm-project/pull/77537
[^4]: https://clang.llvm.org/docs/UsersManual.html#configuration-files
