### PR TITLE
Update wasm-component-ld

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Setup `wasmtime` for tests
       uses: bytecodealliance/actions/wasmtime/setup@v1
       with:
-        version: "18.0.2"
+        version: "29.0.1"
     - name: Install ccache, ninja (macOS)
       run: brew install ccache ninja
       if: runner.os == 'macOS'

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Setup `wasmtime` for tests
       uses: bytecodealliance/actions/wasmtime/setup@v1
       with:
-        version: "22.0.1"
+        version: "29.0.1"
     - name: Install ccache, ninja (macOS)
       run: brew install ccache ninja
       if: runner.os == 'macOS'

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Setup `wasmtime` for tests
       uses: bytecodealliance/actions/wasmtime/setup@v1
       with:
-        version: "29.0.1"
+        version: "22.0.1"
     - name: Install ccache, ninja (macOS)
       run: brew install ccache ninja
       if: runner.os == 'macOS'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,7 @@ jobs:
 
   build-only-sysroot:
     name: Build only sysroot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ci/docker/Dockerfile.common
+++ b/ci/docker/Dockerfile.common
@@ -1,8 +1,8 @@
 # Use a relatively old/stable distro here to maximize the supported platforms
 # and avoid depending on more recent version of, say, libc.
-# Here we choose Bionic 18.04.
+# Here we choose Ubuntu 20.04.
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Various build tooling and such necessary to build LLVM and a wasi-sysroot
 RUN apt-get update \

--- a/cmake/wasi-sdk-toolchain.cmake
+++ b/cmake/wasi-sdk-toolchain.cmake
@@ -119,7 +119,7 @@ install(DIRECTORY ${wasi_tmp_install}/bin ${wasi_tmp_install}/lib ${wasi_tmp_ins
 # Build logic for `wasm-component-ld` installed from Rust code.
 set(wasm_component_ld_root ${CMAKE_CURRENT_BINARY_DIR}/wasm-component-ld)
 set(wasm_component_ld ${wasm_component_ld_root}/bin/wasm-component-ld${CMAKE_EXECUTABLE_SUFFIX})
-set(wasm_component_ld_version 0.5.11)
+set(wasm_component_ld_version 0.5.12)
 if(RUST_TARGET)
   set(rust_target_flag --target=${RUST_TARGET})
 endif()


### PR DESCRIPTION
Pulls in a fix for bytecodealliance/wasmtime#10058 in the adapters that are used by default.