### PR TITLE
Pin CI runner images to explicit versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,7 +178,8 @@ jobs:
             -DCMAKE_C_COMPILER=/usr/lib/llvm-18/bin/clang \
             -DCMAKE_SYSTEM_NAME=WASI \
             -DWASI_SDK_INCLUDE_TESTS=ON \
-            -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF
+            -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF \
+            -DCMAKE_CXX_LINKER_DEPFILE_SUPPORTED=OFF
       - run: ninja -C build
       - run: ctest --output-on-failure --parallel 10 --test-dir build/tests
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,8 @@ jobs:
           cmake -G Ninja -B build -S . \
             -DCMAKE_C_COMPILER=/usr/lib/llvm-18/bin/clang \
             -DCMAKE_SYSTEM_NAME=WASI \
-            -DWASI_SDK_INCLUDE_TESTS=ON
+            -DWASI_SDK_INCLUDE_TESTS=ON \
+            -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF
       - run: ninja -C build
       - run: ctest --output-on-failure --parallel 10 --test-dir build/tests
 
@@ -264,7 +265,6 @@ jobs:
           cmake -G Ninja -B build -S . \
             -DWASI_SDK_INCLUDE_TESTS=ON \
             -DWASI_SDK_TEST_HOST_TOOLCHAIN=ON \
-            -DCMAKE_TOOLCHAIN_FILE=$(ls ./wasi-sdk-*/share/cmake/wasi-sdk.cmake) \
-            -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF
+            -DCMAKE_TOOLCHAIN_FILE=$(ls ./wasi-sdk-*/share/cmake/wasi-sdk.cmake)
       - run: ninja -C build build-tests
       - run: ctest --output-on-failure --parallel 10 --test-dir build/tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,13 +172,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/checkout
       - uses: ./.github/actions/install-deps
-      - run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          name=$(lsb_release -s -c)
-          sudo add-apt-repository -y "deb http://apt.llvm.org/$name/ llvm-toolchain-$name-18 main"
-          sudo add-apt-repository -y "deb-src http://apt.llvm.org/$name/ llvm-toolchain-$name-18 main"
-          sudo apt-get install -y clang-18 llvm-18 lld-18
-      - run: cargo install wasm-component-ld@0.5.5
+      - run: cargo install wasm-component-ld@0.5.12
       - run: |
           cmake -G Ninja -B build -S . \
             -DCMAKE_C_COMPILER=/usr/lib/llvm-18/bin/clang \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         include:
           - artifact: x86_64-linux
-            os: ubuntu-latest
+            os: ubuntu-24.04
 
           - artifact: arm64-linux
-            os: ubuntu-latest
+            os: ubuntu-24.04
             rust_target: aarch64-unknown-linux-gnu
             env:
               # Don't build a sysroot for this cross-compiled target since it
@@ -41,7 +41,7 @@ jobs:
                 -DRUST_TARGET=aarch64-unknown-linux-gnu
 
           - artifact: arm64-macos
-            os: macos-latest
+            os: macos-14
             rust_target: aarch64-apple-darwin
             env:
               WASI_SDK_CI_TOOLCHAIN_LLVM_CMAKE_ARGS: >-
@@ -49,7 +49,7 @@ jobs:
                 -DCMAKE_OSX_ARCHITECTURES=arm64
 
           - artifact: x86_64-macos
-            os: macos-latest
+            os: macos-14
             rust_target: x86_64-apple-darwin
             env:
               WASI_SDK_CI_SKIP_SYSROOT: 1
@@ -58,7 +58,7 @@ jobs:
                 -DCMAKE_OSX_ARCHITECTURES=x86_64
 
           - artifact: x86_64-windows
-            os: windows-latest
+            os: windows-2022
 
     env: ${{ matrix.env || fromJSON('{}') }}
     steps:
@@ -165,7 +165,7 @@ jobs:
 
   build-only-sysroot:
     name: Build only sysroot
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -193,7 +193,7 @@ jobs:
   finalize:
     name: Finalize wasi-sdk artifacts
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -253,7 +253,7 @@ jobs:
   test-standalone:
     name: Test standalone toolchain
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -264,6 +264,7 @@ jobs:
           cmake -G Ninja -B build -S . \
             -DWASI_SDK_INCLUDE_TESTS=ON \
             -DWASI_SDK_TEST_HOST_TOOLCHAIN=ON \
-            -DCMAKE_TOOLCHAIN_FILE=$(ls ./wasi-sdk-*/share/cmake/wasi-sdk.cmake)
+            -DCMAKE_TOOLCHAIN_FILE=$(ls ./wasi-sdk-*/share/cmake/wasi-sdk.cmake) \
+            -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF
       - run: ninja -C build build-tests
       - run: ctest --output-on-failure --parallel 10 --test-dir build/tests

--- a/cmake/wasi-sdk-sysroot.cmake
+++ b/cmake/wasi-sdk-sysroot.cmake
@@ -52,7 +52,8 @@ set(default_cmake_args
   # is just a bare "clang" installation then it can mistakenly deduce that this
   # feature is supported when it's not actually supported for WASI targets.
   # Currently `wasm-ld` does not support the linker flag for this.
-  -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF)
+  -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF
+  -DCMAKE_CXX_LINKER_DEPFILE_SUPPORTED=OFF)
 
 if(CMAKE_C_COMPILER_LAUNCHER)
   list(APPEND default_cmake_args -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER})

--- a/cmake/wasi-sdk-sysroot.cmake
+++ b/cmake/wasi-sdk-sysroot.cmake
@@ -47,7 +47,12 @@ set(default_cmake_args
   -DCMAKE_C_COMPILER_WORKS=ON
   -DCMAKE_CXX_COMPILER_WORKS=ON
   -DCMAKE_SYSROOT=${wasi_sysroot}
-  -DCMAKE_MODULE_PATH=${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+  -DCMAKE_MODULE_PATH=${CMAKE_CURRENT_SOURCE_DIR}/cmake
+  # CMake detects this based on `CMAKE_C_COMPILER` alone and when that compiler
+  # is just a bare "clang" installation then it can mistakenly deduce that this
+  # feature is supported when it's not actually supported for WASI targets.
+  # Currently `wasm-ld` does not support the linker flag for this.
+  -DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF)
 
 if(CMAKE_C_COMPILER_LAUNCHER)
   list(APPEND default_cmake_args -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER})


### PR DESCRIPTION
CI is run infrequently enough on this repository that there's a nontrivial chance that GitHub updates the definition of `ubuntu-latest` for example between two CI runs. This can be confusing for contributors as PRs seemingly break CI when in reality they have nothing to do with the breakage and it's due to the image changing.

This PR pins all images to the definition of `*-latest` at this time. The one exception is that one builder was pinned to 22.04 and I'm going to update it to 24.04 here and see if I can't fix CI issues that come up.

This'll require explicit PRs to update these images in the future, but hopefully that's only once every few ~years so not too much of a burden.