### PR TITLE
Update MacOS image ci to MacOS-15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
                 -DRUST_TARGET=aarch64-unknown-linux-gnu
 
           - artifact: arm64-macos
-            os: macos-14
+            os: macos-15
             rust_target: aarch64-apple-darwin
             env:
               WASI_SDK_CI_TOOLCHAIN_LLVM_CMAKE_ARGS: >-
@@ -49,7 +49,7 @@ jobs:
                 -DCMAKE_OSX_ARCHITECTURES=arm64
 
           - artifact: x86_64-macos
-            os: macos-14
+            os: macos-15
             rust_target: x86_64-apple-darwin
             env:
               WASI_SDK_CI_SKIP_SYSROOT: 1


### PR DESCRIPTION
This PR adds to the ci jobs which cover MacOS 15. This allows the ci to cover the 2 most recent versions of MacOS.