### PR TITLE
Update Windows image CI to Windows-2025

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
                 -DCMAKE_OSX_ARCHITECTURES=x86_64
 
           - artifact: x86_64-windows
-            os: windows-2022
+            os: windows-2025
 
     env: ${{ matrix.env || fromJSON('{}') }}
     steps:


### PR DESCRIPTION
This PR adds a Windows 2025 job to the ci, so that the 2 most recent versions of Windows server which are available as Github runners are supported by the ci.