### PR TITLE
Update Dockerfile to Ubuntu 24.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 # pre-built versions of this container are pushed as a package to the repository
 # as well.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get install -y cmake ninja-build make autoconf autogen automake libtool && \


### PR DESCRIPTION
The Dockerfile within this repo is set to Ubuntu 22.04 . This PR updates the version to the latest LTS version (24.04)