### PR TITLE
Add comment for ARM64 package installation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ A typical installation from the release binaries might look like the following:
 
 ```shell script
 WASI_OS=linux
-WASI_ARCH=x86_64 // (`WASI_ARCH=arm64` for ARM64 package)
+WASI_ARCH=x86_64 # or 'arm64' if running on arm64 host
 WASI_VERSION=24
 WASI_VERSION_FULL=${WASI_VERSION}.0
 wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ A typical installation from the release binaries might look like the following:
 
 ```shell script
 WASI_OS=linux
-WASI_ARCH=x86_64
+WASI_ARCH=x86_64 // (`WASI_ARCH=arm64` for ARM64 package)
 WASI_VERSION=24
 WASI_VERSION_FULL=${WASI_VERSION}.0
 wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz


### PR DESCRIPTION
Hi! I added `WASI_ARCH=arm64` command for the arm64 package version to the installation command’s comment. I thought this would make the command more clear.