### PR TITLE
[ci] Install cmake and ninja from apt ci Dockerfile

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -15,26 +15,9 @@ RUN apt-get update \
   python3 \
   git \
   unzip \
-  xz-utils
-
-# Install a more recent version of CMake than what 18.04 has since that's what
-# LLVM requires.
-RUN ARCH=$(uname -m) \
-  && curl -sSLO https://github.com/Kitware/CMake/releases/download/v3.29.5/cmake-3.29.5-linux-${ARCH}.tar.gz \
-  && tar xf cmake-3.29.5-linux-${ARCH}.tar.gz \
-  && rm cmake-3.29.5-linux-${ARCH}.tar.gz \
-  && mkdir -p /opt \
-  && mv cmake-3.29.5-linux-${ARCH} /opt/cmake
-
-ENV PATH /opt/cmake/bin:$PATH
-
-# As with CMake install a later version of Ninja than waht 18.04 has.
-RUN ARCH=$(uname -m) \
-  && if [ "$ARCH" = "aarch64"  ]; then SUFFIX=-aarch64; fi \
-  && curl -sSL -o ninja.zip https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux${SUFFIX}.zip \
-  && unzip ninja.zip \
-  && rm *.zip \
-  && mv ninja /opt/cmake/bin
+  xz-utils \
+  cmake \
+  ninja-build
 
 # Tell programs to cache in a location that both isn't a `--volume` mounted root
 # and isn't `/root` in the container as that won't be writable during the build.


### PR DESCRIPTION
In the ci Dockerfile it says cmake and ninja are fetched from Github releases since Ubuntu 18.04 doesn't have a new enough version to build llvm. The Dockerfile now uses Ubuntu 20.04, so this might no longer be needed, and these can be got from apt, simplifying the Dockerfile.