### PR TITLE
[ci] Update submodules independently ci

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -7,10 +7,14 @@ runs:
     - run: git fetch --tags --force
       name: Force-fetch tags to work around actions/checkout#290
       shell: bash
-    # We can't use `--depth 1` here sadly because the GNU config
-    # submodule is not pinned to a particular tag/branch. Please
+    # We can't use `--depth 1` for the GNU config submodule
+    # here sadly because is not pinned to a particular tag/branch. Please
     # bump depth (or even better, the submodule), in case of "error:
     # Server does not allow request for unadvertised object" in the
     # future.
-    - run: git submodule update --init --depth 64 --jobs 3
+    - run: |
+        git submodule update --init --depth 64 src/config
+        git submodule update --init --depth 1 src/llvm-project
+        git submodule update --init --depth 1 src/wasi-libc
+
       shell: bash


### PR DESCRIPTION
I'm not so sure how this PR will be received (since it increases the number of lines in the action), but decided to put in anyway. In the checkout/action.yml file there is a comment that --depth 1 cannot be used since the config submodule is not fixed to a tag/branch. Given the size of llvm-project its probably worth separating out the config submodule update, so that other submodules can be updated with depth 1. This may lead to a small increase (not sure how noticeable until ci runs) in speed of the ci, given the size of the llvm-project submodule. I also admit I may be completely wrong in this assumption.