### PR TITLE
Fix 5 warnings found (use docker --debug to expand)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,8 +20,8 @@ RUN case `dpkg --print-architecture` in \
   esac && \
   rm wasi-sdk-*.deb
 
-ENV CC /opt/wasi-sdk/bin/clang
-ENV CXX /opt/wasi-sdk/bin/clang++
-ENV LD /opt/wasi-sdk/bin/wasm-ld
-ENV AR /opt/wasi-sdk/bin/llvm-ar
-ENV RANLIB /opt/wasi-sdk/bin/llvm-ranlib
+ENV CC="/opt/wasi-sdk/bin/clang"
+ENV CXX="/opt/wasi-sdk/bin/clang++"
+ENV LD="/opt/wasi-sdk/bin/wasm-ld"
+ENV AR="/opt/wasi-sdk/bin/llvm-ar"
+ENV RANLIB="/opt/wasi-sdk/bin/llvm-ranlib"


### PR DESCRIPTION
This PR can fix:

5 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 23)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 24)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 25)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 26)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 27)