### PR TITLE
Add Windows 11 arm support to ci

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -16,6 +16,8 @@ runs:
       run: choco install ccache ninja
       if: startsWith(matrix.os, 'windows')
       shell: bash
+      # Windows arm runners don't come with rust by default (see https://github.com/actions/partner-runner-images/blob/main/images/arm-windows-11-image.md)
+      # but the x86 ones do (see https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md)
     - name: Install cargo (Windows-arm)
       run: choco install rust
       if: matrix.os == 'windows-11-arm'

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -14,7 +14,11 @@ runs:
       shell: bash
     - name: Install ccache, ninja (Windows)
       run: choco install ccache ninja
-      if: runner.os == 'Windows'
+      if: startsWith(matrix.os, 'windows')
+      shell: bash
+    - name: Install cargo (Windows-arm)
+      run: choco install rust
+      if: matrix.os == 'windows-11-arm'
       shell: bash
     - name: Install ccache, ninja (Linux)
       run: sudo apt-get install -y ccache ninja-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,9 @@ jobs:
           - artifact: x86_64-windows
             os: windows-2022
 
+          - artifact: arm64-windows
+            os: windows-11-arm
+
     env: ${{ matrix.env || fromJSON('{}') }}
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +105,7 @@ jobs:
       #
       # As of 2024-07-22 this sha is the "v1.13.0" tag.
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
-        if: runner.os == 'Windows'
+        if: startsWith(matrix.os, 'windows')
       - name: Build and test (Windows)
         run: |
           # Delete a troublesome binary as recommended here
@@ -117,7 +120,7 @@ jobs:
           mkdir build
           cp -r C:/wasi-sdk/dist build
         shell: bash
-        if: runner.os == 'Windows'
+        if: startsWith(matrix.os, 'windows')
 
       # Upload the `dist` folder from the build as the artifacts for this
       # runner.


### PR DESCRIPTION
This PR should hopefully fix https://github.com/WebAssembly/wasi-sdk/issues/522 . According to https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/ Windows arm Github runners are now available for free for public repositories. Therefore I have added them to wasi-sdks ci.