### PR TITLE
Update README's installation instructions to latest release number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ A typical installation from the release binaries might look like the following:
 ```shell script
 WASI_OS=linux
 WASI_ARCH=x86_64 # or 'arm64' if running on arm64 host
-WASI_VERSION=24
+WASI_VERSION=25
 WASI_VERSION_FULL=${WASI_VERSION}.0
 wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz
 tar xvf wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz


### PR DESCRIPTION
Just bumped the version number in the Install's shell script code block (point to the latest release).