### PR TITLE
Enable per-target runtime directory for compiler-rt

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ convenience.
 One could also use a standard Clang installation, build a sysroot from the
 sources mentioned above, and compile with `--target=wasm32-wasi
 --sysroot=/path/to/sysroot`. In this scenario, one would also need the
-`libclang_rt.builtins-wasm32.a` objects available separately in the [release
+`libclang_rt.*.a` objects available separately in the [release
 downloads][releases] which must be extracted into
-`$CLANG_INSTALL_DIR/$CLANG_VERSION/lib/wasi/`.
+`$CLANG_INSTALL_DIR/$CLANG_VERSION/lib/`.
 
 ## Clone
 

--- a/ci/merge-artifacts.sh
+++ b/ci/merge-artifacts.sh
@@ -62,12 +62,10 @@ for build in dist-*; do
   tar xf $sysroot -C dist/$sdk_dir/share/wasi-sysroot --strip-components 1
   mv dist/$sdk_dir/share/wasi-sysroot/VERSION dist/$sdk_dir
 
-  # Setup the compiler-rt library for wasi,wasip1,wasip2
+  # Setup the compiler-rt library for all targets.
   rtlibdir=$(dirname $(find dist/$sdk_dir/lib -name include))/lib
-  mkdir -p $rtlibdir/wasi
-  tar xf $compiler_rt -C $rtlibdir/wasi --strip-components 1
-  cp -r $rtlibdir/wasi $rtlibdir/wasip1
-  cp -r $rtlibdir/wasi $rtlibdir/wasip2
+  mkdir -p $rtlibdir
+  tar xf $compiler_rt -C $rtlibdir --strip-components 1
 
   tar czf dist/$sdk_dir.tar.gz -C dist $sdk_dir
 


### PR DESCRIPTION
This change allows us to have per-target libclang_rt.* libraries instead of per-OS. This is particularly required for w/threads and wo/threads targets, whose rt libraries could be incompatible even with the same OS string.

This change starts building `compiler-rt` for w/threads and wo/threads separately, so that we can enable thread-related features for p1-threads target for building upcoming ASan clang_rt libraries. Also `COMPILER_RT_OS_DIR` is not set anymore as it's unused when `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR` is enabled.