### PR TITLE
Enable pthreads in libc++ for `THREAD_MODEL=single`

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,20 @@ See [C setjmp/longjmp support] about setjmp/longjmp support.
 [C setjmp/longjmp support]: SetjmpLongjmp.md
 
 This repository experimentally supports __threads__ with
-`--target=wasm32-wasi-threads`. It uses WebAssembly's [threads] primitives
+`--target=wasm32-wasip1-threads`. It uses WebAssembly's [threads] primitives
 (atomics, `wait`/`notify`, shared memory) and [wasi-threads] for spawning
 threads. Note: this is experimental &mdash; do not expect long-term stability!
+
+Note that the `pthread_*` family of functions, as well as C++ threading primitives
+such as `<atomic>`, `<mutex>`, and `<thread>` are available on all targets.
+Any attempt to spawn a thread will fail on `--target=wasm32-wasip1` or
+`--target=wasm32-wasip2`, but other functionality, such as locks, still works.
+This makes it easier to port C++ codebases, as only a fraction of code needs
+to be modified to build for the single-threaded targets.
+
+Defining a macro `_WASI_STRICT_PTHREAD` will make `pthread_create`,
+`pthread_detach`, `pthread_join`, `pthread_tryjoin_np`, and `pthread_timedjoin_np`
+fail with a compile time error when building for single-threaded targets.
 
 [threads]: https://github.com/WebAssembly/threads
 [wasi-threads]: https://github.com/WebAssembly/wasi-threads

--- a/cmake/wasi-sdk-sysroot.cmake
+++ b/cmake/wasi-sdk-sysroot.cmake
@@ -222,11 +222,9 @@ execute_process(
 
 function(define_libcxx_sub target target_suffix extra_target_flags extra_libdir_suffix)
   if(${target} MATCHES threads)
-    set(threads ON)
     set(pic OFF)
     set(target_flags -pthread)
   else()
-    set(threads OFF)
     set(pic ON)
     set(target_flags "")
   endif()
@@ -262,8 +260,8 @@ function(define_libcxx_sub target target_suffix extra_target_flags extra_libdir_
       -DCMAKE_STAGING_PREFIX=${wasi_sysroot}
       -DCMAKE_POSITION_INDEPENDENT_CODE=${pic}
       -DCXX_SUPPORTS_CXX11=ON
-      -DLIBCXX_ENABLE_THREADS:BOOL=${threads}
-      -DLIBCXX_HAS_PTHREAD_API:BOOL=${threads}
+      -DLIBCXX_ENABLE_THREADS:BOOL=ON
+      -DLIBCXX_HAS_PTHREAD_API:BOOL=ON
       -DLIBCXX_HAS_EXTERNAL_THREAD_API:BOOL=OFF
       -DLIBCXX_BUILD_EXTERNAL_THREAD_LIBRARY:BOOL=OFF
       -DLIBCXX_HAS_WIN32_THREAD_API:BOOL=OFF
@@ -280,8 +278,8 @@ function(define_libcxx_sub target target_suffix extra_target_flags extra_libdir_
       -DLIBCXXABI_ENABLE_EXCEPTIONS:BOOL=OFF
       -DLIBCXXABI_ENABLE_SHARED:BOOL=${pic}
       -DLIBCXXABI_SILENT_TERMINATE:BOOL=ON
-      -DLIBCXXABI_ENABLE_THREADS:BOOL=${threads}
-      -DLIBCXXABI_HAS_PTHREAD_API:BOOL=${threads}
+      -DLIBCXXABI_ENABLE_THREADS:BOOL=ON
+      -DLIBCXXABI_HAS_PTHREAD_API:BOOL=ON
       -DLIBCXXABI_HAS_EXTERNAL_THREAD_API:BOOL=OFF
       -DLIBCXXABI_BUILD_EXTERNAL_THREAD_LIBRARY:BOOL=OFF
       -DLIBCXXABI_HAS_WIN32_THREAD_API:BOOL=OFF


### PR DESCRIPTION
This commit enables thread support in libc++ for all thread models, enabling C++ applications that use threading APIs like `<atomic>` but do not spawn threads (e.g. Clang) to be built with minimal changes.

Fixes #546.

Depends on WebAssembly/wasi-libc#602.