### PR TITLE
Update github CI concurrency key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This bit me while releasing wasi-sdk-26/27 because while I tried to get both builds going at once they overlapped in their key meaning that they had to progress one-at-a-time. This uses `github.ref` instead of the PR number which I think should be more robust in situations like this.