### PR TITLE
Lower linux glibc requirement from 2.31 to 2.28

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -14,13 +14,10 @@ RUN dnf install -y \
   unzip \
   cmake
 
-RUN ARCH=$(uname -m) \
-  && curl -sSLO https://github.com/ccache/ccache/releases/download/v4.12.1/ccache-4.12.1-linux-${ARCH}.tar.xz \
-  && tar -xf ccache-4.12.1-linux-${ARCH}.tar.xz \
-  && rm ccache-4.12.1-linux-${ARCH}.tar.xz \
-  && mv ccache-4.12.1-linux-${ARCH} /opt/ccache
+COPY ./install-ccache.sh .
+RUN ./install-ccache.sh
 
-ENV PATH /opt/ccache:$PATH
+ENV PATH /opt/ccache/bin:$PATH
 
 # AlmaLinux 8 doesn't seem to have ninja, so install it manually.
 RUN ARCH=$(uname -m) \
@@ -28,7 +25,7 @@ RUN ARCH=$(uname -m) \
   && curl -sSL -o ninja.zip https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux${SUFFIX}.zip \
   && unzip ninja.zip \
   && rm *.zip \
-  && mv ninja /opt/ccache
+  && mv ninja /opt/ccache/bin
 
 # Tell programs to cache in a location that both isn't a `--volume` mounted root
 # and isn't `/root` in the container as that won't be writable during the build.

--- a/ci/docker/install-ccache.sh
+++ b/ci/docker/install-ccache.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# AlmaLinux 8, the container this script runs in, does not have ccache in its
+# package repositories. The ccache project publishes both x86_64 and aarch64
+# binaries, however. The x86_64 binaries for ccache are themselves built in
+# AlmaLinux 8 so they're compatible, but the aarch64 binaries are built in a
+# newer container and don't run on AlmaLinux 8.
+#
+# Thus this script downloads precompiled binaries for x86_64 but builds from
+# source on aarch64.
+
+ARCH=$(uname -m)
+ver=4.12.1
+
+if [ "x$ARCH" = "x86_64" ]; then
+  curl -sSLO https://github.com/ccache/ccache/releases/download/v${ver}/ccache-${ver}-linux-${ARCH}.tar.xz
+  tar -xf ccache-${ver}-linux-${ARCH}.tar.xz
+  rm ccache-${ver}-linux-${ARCH}.tar.xz
+  mv ccache-${ver}-linux-${ARCH} /opt/ccache/bin
+else
+  curl -sSLO https://github.com/ccache/ccache/releases/download/v${ver}/ccache-${ver}.tar.xz
+  tar -xf ccache-${ver}.tar.xz
+
+  cd ccache-${ver}
+  mkdir build
+  cd build
+  cmake .. \
+    -DCMAKE_INSTALL_PREFIX=/opt/ccache \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DHTTP_STORAGE_BACKEND=OFF \
+    -DENABLE_TESTING=OFF \
+    -DREDIS_STORAGE_BACKEND=OFF
+  make -j$(nproc)
+  make install
+fi


### PR DESCRIPTION


In componentize-py Joel's building custom wasi-sdk binaries for more
Linux compat which is what maturin, the build tool use there, desires. I
don't think there's a concrete reason to have a higher Linux version
here, so let's lower it in wasi-sdk itself.

This commit switches the build container from Ubuntu 20.04 (glibc 2.31)
to AlmaLinux 8 (glibc 2.28). The AlmaLinux container is what Wasmtime
uses, for example, and has supported security updates to 2029 and is I
believe intended to be used for purposes such as this.

