### PR TITLE
doc: add cargo to list of requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The Wasm-sdk's build process needs some packages :
 * `clang`
 * `ninja`
 * `python3`
+* `cargo`
 
 Please refer to your OS documentation to install those packages.
 


### PR DESCRIPTION
During the build step, cargo is needed but this was not listed under requirements.