### PR TITLE
Include `libclang.so` in wasi-sdk

### DIFF
--- a/cmake/wasi-sdk-toolchain.cmake
+++ b/cmake/wasi-sdk-toolchain.cmake
@@ -57,7 +57,8 @@ set(tools
   objdump
   objcopy
   c++filt
-  llvm-config)
+  llvm-config
+  libclang)
 
 # By default link LLVM dynamically to all the various tools. This greatly
 # reduces the binary size of all the tools through a shared library rather than


### PR DESCRIPTION
This includes a new library, `libclang.so`, which is Clang's public C API. This is used by tooling such as Rust's `bindgen` library to generate bindings and can be useful when bindings are generated using a wasi-sdk distribution.