### PR TITLE
Change Clang's default target to `wasm32-wasip1`

### DIFF
--- a/cmake/wasi-sdk-toolchain.cmake
+++ b/cmake/wasi-sdk-toolchain.cmake
@@ -88,7 +88,7 @@ ExternalProject_Add(llvm-build
     -DLLVM_INCLUDE_BENCHMARKS=OFF
     -DLLVM_INCLUDE_EXAMPLES=OFF
     -DLLVM_TARGETS_TO_BUILD=WebAssembly
-    -DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-wasi
+    -DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-wasip1
     -DLLVM_INSTALL_BINUTILS_SYMLINKS=TRUE
     -DLLVM_ENABLE_LIBXML2=OFF
     # Pass `-s` to strip symbols by default and shrink the size of the


### PR DESCRIPTION
No longer use `wasm32-wasi` since Clang issues a deprecation warning about that. This fixes the `clang` binary, by default, emitting a warning for example in the final build.