### PR TITLE
ci: add riscv64-linux build via cross-compilation on ubuntu-24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,16 @@ jobs:
           - artifact: arm64-linux
             os: ubuntu-22.04-arm
 
+          - artifact: riscv64-linux
+            os: ubuntu-24.04
+            rust_target: riscv64-unknown-linux-gnu
+            cross_cmake_args: >-
+              -DCMAKE_SYSTEM_NAME=Linux
+              -DCMAKE_SYSTEM_PROCESSOR=riscv64
+              -DWASI_SDK_LLDB=OFF
+            env:
+              WASI_SDK_CI_SKIP_SYSROOT: 1
+
           - artifact: arm64-macos
             os: macos-14
             rust_target: aarch64-apple-darwin
@@ -84,6 +94,9 @@ jobs:
           if [ "${{ matrix.rust_target }}" != "" ]; then
             rustup target add ${{ matrix.rust_target }}
             cmake_args="$cmake_args -DRUST_TARGET=${{ matrix.rust_target }}"
+          fi
+          if [ "${{ matrix.cross_cmake_args }}" != "" ]; then
+            cmake_args="$cmake_args ${{ matrix.cross_cmake_args }}"
           fi
           echo WASI_SDK_CI_TOOLCHAIN_CMAKE_ARGS="$cmake_args" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,14 @@ jobs:
             cross_cmake_args: >-
               -DCMAKE_SYSTEM_NAME=Linux
               -DCMAKE_SYSTEM_PROCESSOR=riscv64
+              -DCMAKE_C_COMPILER=riscv64-linux-gnu-gcc
+              -DCMAKE_CXX_COMPILER=riscv64-linux-gnu-g++
               -DWASI_SDK_LLDB=OFF
             env:
               WASI_SDK_CI_SKIP_SYSROOT: 1
+              WASI_SDK_CI_TOOLCHAIN_LLVM_CMAKE_ARGS: >-
+                -DCMAKE_SYSTEM_NAME=Linux
+                -DCMAKE_SYSTEM_PROCESSOR=riscv64
 
           - artifact: arm64-macos
             os: macos-14

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
           - artifact: riscv64-linux
             os: ubuntu-24.04
-            rust_target: riscv64-unknown-linux-gnu
+            rust_target: riscv64gc-unknown-linux-gnu
             cross_cmake_args: >-
               -DCMAKE_SYSTEM_NAME=Linux
               -DCMAKE_SYSTEM_PROCESSOR=riscv64

--- a/ci/docker-build.sh
+++ b/ci/docker-build.sh
@@ -15,8 +15,13 @@ fi
 
 set -x
 
-# Build the Docker imager
-docker build --tag wasi-sdk-builder ci/docker
+# Build the Docker image. Use an artifact-specific Dockerfile if one exists
+# (e.g. ci/docker/Dockerfile.riscv64-linux), otherwise use the default.
+dockerfile=ci/docker/Dockerfile
+if [ -f "ci/docker/Dockerfile.$1" ]; then
+  dockerfile="ci/docker/Dockerfile.$1"
+fi
+docker build --tag wasi-sdk-builder --file "$dockerfile" ci/docker
 
 # Perform the build in `/src`. The current directory is mounted read-write at
 # this location as well. To ensure that container-created files are reasonable
@@ -34,9 +39,11 @@ args="$args --volume $ccache_dir:/ccache:Z --env CCACHE_DIR=/ccache"
 
 # Inherit some tools from the host into this container. This ensures that the
 # decision made on CI of what versions to use is the canonical source of truth
-# for theset ools
+# for these tools.
 args="$args --volume `rustc --print sysroot`:/rustc:ro"
-args="$args --volume $(dirname $(which wasmtime)):/wasmtime:ro"
+if [ "${WASI_SDK_CI_SKIP_SYSROOT:-}" != "1" ]; then
+  args="$args --volume $(dirname $(command -v wasmtime)):/wasmtime:ro"
+fi
 
 # Pass through some env vars that `build.sh` reads
 args="$args --env WASI_SDK_CI_TOOLCHAIN_CMAKE_ARGS"

--- a/ci/docker/Dockerfile.riscv64-linux
+++ b/ci/docker/Dockerfile.riscv64-linux
@@ -1,0 +1,30 @@
+# Ubuntu 24.04 is used here (rather than AlmaLinux 8) because it has
+# riscv64 cross-compilation packages in its repositories.
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  curl \
+  ca-certificates \
+  crossbuild-essential-riscv64 \
+  clang \
+  lld \
+  python3 \
+  git \
+  unzip \
+  cmake \
+  ninja-build \
+  ccache \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set the cross-compiler as the default so that cmake picks it up via CC/CXX
+# and sets CMAKE_CROSSCOMPILING=TRUE, which causes LLVM to build a native
+# tablegen before cross-compiling the rest of the toolchain.
+ENV CC=riscv64-linux-gnu-gcc
+ENV CXX=riscv64-linux-gnu-g++
+
+# Cargo needs an explicit linker when cross-compiling for riscv64.
+ENV CARGO_TARGET_RISCV64_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
+
+# Tell programs to cache in a location that both isn't a `--volume` mounted root
+# and isn't `/root` in the container as that won't be writable during the build.
+ENV XDG_CACHE_HOME=/tmp/cache

--- a/ci/docker/Dockerfile.riscv64-linux
+++ b/ci/docker/Dockerfile.riscv64-linux
@@ -23,7 +23,7 @@ ENV CC=riscv64-linux-gnu-gcc
 ENV CXX=riscv64-linux-gnu-g++
 
 # Cargo needs an explicit linker when cross-compiling for riscv64.
-ENV CARGO_TARGET_RISCV64_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
+ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
 
 # Tell programs to cache in a location that both isn't a `--volume` mounted root
 # and isn't `/root` in the container as that won't be writable during the build.

--- a/ci/docker/Dockerfile.riscv64-linux
+++ b/ci/docker/Dockerfile.riscv64-linux
@@ -16,13 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ccache \
   && rm -rf /var/lib/apt/lists/*
 
-# Set the cross-compiler as the default so that cmake picks it up via CC/CXX
-# and sets CMAKE_CROSSCOMPILING=TRUE, which causes LLVM to build a native
-# tablegen before cross-compiling the rest of the toolchain.
-ENV CC=riscv64-linux-gnu-gcc
-ENV CXX=riscv64-linux-gnu-g++
-
 # Cargo needs an explicit linker when cross-compiling for riscv64.
+# The C/C++ cross-compiler is passed via CMAKE_C/CXX_COMPILER cmake flags
+# rather than CC/CXX env vars so that LLVM's native tblgen sub-build can
+# still find the host compiler (cmake cache vars are not inherited by
+# subprocess cmake invocations, but env vars are).
 ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
 
 # Tell programs to cache in a location that both isn't a `--volume` mounted root

--- a/ci/merge-artifacts.sh
+++ b/ci/merge-artifacts.sh
@@ -21,8 +21,9 @@ make_deb() {
   fi
 
   case $build in
-    dist-x86_64-linux) deb_arch=amd64 ;;
-    dist-arm64-linux)  deb_arch=arm64 ;;
+    dist-x86_64-linux)  deb_arch=amd64   ;;
+    dist-arm64-linux)   deb_arch=arm64   ;;
+    dist-riscv64-linux) deb_arch=riscv64 ;;
     *)
       echo "unknown build $build"
       exit 1


### PR DESCRIPTION
Rework of the riscv64-linux CI build to use CMake cross-compilation on a standard `ubuntu-24.04` runner, rather than a native RISE runner.

## What changed

**`ci/docker/Dockerfile.riscv64-linux`** (new):
- Ubuntu 24.04 base — has `crossbuild-essential-riscv64` in its package repos
- Sets `CC=riscv64-linux-gnu-gcc` / `CXX=riscv64-linux-gnu-g++` so CMake detects cross-compilation and causes LLVM to build a native `llvm-tblgen` first, then cross-compile the rest of the toolchain
- Sets `CARGO_TARGET_RISCV64_UNKNOWN_LINUX_GNU_LINKER` for Rust cross-builds
- `XDG_CACHE_HOME=/tmp/cache` avoids write permission issues in the container

**`ci/docker-build.sh`**:
- Select `ci/docker/Dockerfile.<artifact>` if it exists, fall back to the default `ci/docker/Dockerfile`
- Make the wasmtime volume mount conditional on `WASI_SDK_CI_SKIP_SYSROOT != 1`

**`.github/workflows/main.yml`**:
- New `riscv64-linux` matrix entry: `os: ubuntu-24.04`, `rust_target: riscv64-unknown-linux-gnu`
- `cross_cmake_args: -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=riscv64 -DWASI_SDK_LLDB=OFF`
- `WASI_SDK_CI_SKIP_SYSROOT: 1`
- Handle `cross_cmake_args` in the cmake flags step

## Why WASI_SDK_CI_SKIP_SYSROOT

The cross-compiled clang runs on riscv64, not on the x86_64 build host, so the wasm sysroot step is skipped.

## Why WASI_SDK_LLDB=OFF

Avoids cross-compiling libedit and libxml2 in this first iteration; can be re-enabled as a follow-up.

Closes #607