### PR TITLE
Add clang-scan-deps to the toolchain

### DIFF
--- a/cmake/wasi-sdk-toolchain.cmake
+++ b/cmake/wasi-sdk-toolchain.cmake
@@ -56,6 +56,7 @@ set(tools
   clang-format
   clang-tidy
   clang-apply-replacements
+  clang-scan-deps
   lld
   llvm-addr2line
   llvm-mc


### PR DESCRIPTION
I tried to built it locally but failed, hopefully CI can do it.

Closes #618