### PR TITLE
Add WASI_SDK_BUILD_SHARED option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,6 +181,8 @@ jobs:
           - name: default
           - name: exceptions
             defines: -DWASI_SDK_EXCEPTIONS=ON
+          - name: static
+            defines: -DWASI_SDK_BUILD_SHARED=OFF
     steps:
       - uses: actions/checkout@v6
         with:

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ in compiling WebAssembly code. Supported CMake flags are:
   to enable/disable. The default is `-mcpu=lime1`.
 * `-DWASI_SDK_LTO=ON` - whether to enable/disable builds of LTO-capable
   libraries as part of the build.
+* `-DWASI_SDK_BUILD_SHARED=ON` - whether to build shared libraries (`libc.so`,
+  `libc++.so`, etc.) for targets that support them. Set to `OFF` to produce a
+  static-only sysroot.
 * `-DWASI_SDK_EXCEPTIONS=ON` - whether to enable/disable support for C++
   exceptions, see [CppExceptions.md](./CppExceptions.md) for more information.
 * `-DWASI_SDK_TEST_HOST_TOOLCHAIN=ON` - test the host toolchain's wasi-libc and

--- a/cmake/wasi-sdk-sysroot.cmake
+++ b/cmake/wasi-sdk-sysroot.cmake
@@ -29,6 +29,7 @@ option(WASI_SDK_DEBUG_PREFIX_MAP "Pass `-fdebug-prefix-map` for built artifacts"
 option(WASI_SDK_INCLUDE_TESTS "Whether or not to build tests by default" OFF)
 option(WASI_SDK_INSTALL_TO_CLANG_RESOURCE_DIR "Whether or not to modify the compiler's resource directory" OFF)
 option(WASI_SDK_LTO "Whether or not to build LTO assets" ON)
+option(WASI_SDK_BUILD_SHARED "Whether or not to build shared libraries when supported" ON)
 set(WASI_SDK_EXCEPTIONS "${EXCEPTIONS_DEFAULT}" CACHE STRING "Whether or not C++ exceptions are enabled")
 set(WASI_SDK_CPU_CFLAGS "-mcpu=lime1" CACHE STRING "CFLAGS to specify wasm features to enable")
 
@@ -192,9 +193,14 @@ function(define_wasi_libc_sub target target_suffix lto)
   set(extra_cmake_args)
 
   # Configure LTO in wasi libc if it's enabled. Be sure to disable shared
-  # libraries as well since that's not currently supported.
+  # libraries as well since that's not currently supported with LTO.
   if (lto)
-    list(APPEND extra_cmake_args -DLTO=full -DBUILD_SHARED=OFF)
+    list(APPEND extra_cmake_args -DLTO=full)
+  endif()
+  # WASI_SDK_BUILD_SHARED=OFF allows producing a static-only sysroot; the LTO
+  # branch above already implies shared-off, so the two conditions are combined.
+  if (lto OR NOT WASI_SDK_BUILD_SHARED)
+    list(APPEND extra_cmake_args -DBUILD_SHARED=OFF)
   endif()
 
   ExternalProject_Add(wasi-libc-${target}${target_suffix}-build
@@ -292,6 +298,15 @@ function(define_libcxx_sub target target_suffix extra_target_flags extra_libdir_
     list(APPEND extra_flags -Wno-deprecated)
   endif()
 
+  # `shared` is computed here, after the exceptions branch above may have forced
+  # pic OFF, so that LIBCXX_ENABLE_SHARED/LIBCXXABI_ENABLE_SHARED/LIBUNWIND_ENABLE_SHARED
+  # stay consistent with the final value of CMAKE_POSITION_INDEPENDENT_CODE.
+  if(WASI_SDK_BUILD_SHARED AND pic)
+    set(shared ON)
+  else()
+    set(shared OFF)
+  endif()
+
   set(extra_cflags_list ${CMAKE_C_FLAGS} ${extra_flags})
   list(JOIN extra_cflags_list " " extra_cflags)
   set(extra_cxxflags_list ${CMAKE_CXX_FLAGS} ${extra_flags})
@@ -311,7 +326,7 @@ function(define_libcxx_sub target target_suffix extra_target_flags extra_libdir_
       -DLIBCXX_HAS_EXTERNAL_THREAD_API:BOOL=OFF
       -DLIBCXX_HAS_WIN32_THREAD_API:BOOL=OFF
       -DLLVM_COMPILER_CHECKED=ON
-      -DLIBCXX_ENABLE_SHARED:BOOL=${pic}
+      -DLIBCXX_ENABLE_SHARED:BOOL=${shared}
       -DLIBCXX_ENABLE_EXCEPTIONS:BOOL=${exceptions}
       -DLIBCXX_ENABLE_FILESYSTEM:BOOL=ON
       -DLIBCXX_ENABLE_ABI_LINKER_SCRIPT:BOOL=OFF
@@ -319,14 +334,14 @@ function(define_libcxx_sub target target_suffix extra_target_flags extra_libdir_
       -DLIBCXX_HAS_MUSL_LIBC:BOOL=OFF
       -DLIBCXX_ABI_VERSION=2
       -DLIBCXXABI_ENABLE_EXCEPTIONS:BOOL=${exceptions}
-      -DLIBCXXABI_ENABLE_SHARED:BOOL=${pic}
+      -DLIBCXXABI_ENABLE_SHARED:BOOL=${shared}
       -DLIBCXXABI_SILENT_TERMINATE:BOOL=ON
       -DLIBCXXABI_ENABLE_THREADS:BOOL=ON
       -DLIBCXXABI_HAS_PTHREAD_API:BOOL=ON
       -DLIBCXXABI_HAS_EXTERNAL_THREAD_API:BOOL=OFF
       -DLIBCXXABI_HAS_WIN32_THREAD_API:BOOL=OFF
       -DLIBCXXABI_USE_LLVM_UNWINDER:BOOL=${exceptions}
-      -DLIBUNWIND_ENABLE_SHARED:BOOL=${pic}
+      -DLIBUNWIND_ENABLE_SHARED:BOOL=${shared}
       -DLIBUNWIND_ENABLE_THREADS:BOOL=ON
       -DLIBUNWIND_USE_COMPILER_RT:BOOL=ON
       -DLIBUNWIND_INCLUDE_TESTS:BOOL=OFF


### PR DESCRIPTION
Adds a new CMake option, defaulting to `ON` so existing builds are unaffected. When set to `OFF`, `wasi-libc` is built with `-DBUILD_SHARED=OFF` (its existing `if (NOT BUILD_SHARED)` block then short-circuits the per-target `set(SHARED ON)` for `wasm32-wasi`/`wasm32-wasip1`), and the `libcxx`/`libcxxabi`/`libunwind` invocations no longer use `${pic}` directly for their `*_ENABLE_SHARED` flags — they go through a new local `shared` variable that AND's `WASI_SDK_BUILD_SHARED` with `${pic}`.

Motivation: downstream consumers that build wasi-sdk from source as part of a larger toolchain pipeline (in our case, Firefox's build system) don't ship or link against shared sysroot artifacts. The current code path provides no way to opt out, so we've been patching locally. The existing comment in `wasi-sdk-sysroot.cmake` notes shared libraries aren't supported with LTO; this doesn't change that default, it just exposes the same toggle for non-LTO builds too.

A `static` entry is added to the `build-only-sysroot` CI matrix to exercise the OFF path.